### PR TITLE
feat(agent): bilingual TTS routing (EN+RU)

### DIFF
--- a/infra/.env.example
+++ b/infra/.env.example
@@ -43,11 +43,17 @@ VLLM_API_KEY=REPLACE_ME_openssl_rand_hex_32
 # but setting a token avoids rate limits on first download.
 HUGGING_FACE_HUB_TOKEN=
 
-# ── TTS voice (Piper) ───────────────────────────────────────────────────────
-# Russian voices: ru_RU-ruslan-medium, ru_RU-irina-medium, ru_RU-denis-medium, ru_RU-dmitri-medium
-# English voices: en_US-ryan-high, en_US-amy-medium, en_GB-alan-medium
+# ── TTS voices (Piper) ──────────────────────────────────────────────────────
+# Two voices loaded simultaneously, one per supported output language. The
+# agent's bilingual router (services/agent/lang.py) detects the language of
+# each LLM output and routes to the matching voice.
+#
+# English voices: en_US-amy-medium, en_US-ryan-high, en_GB-alan-medium
+# Russian voices: ru_RU-ruslan-medium, ru_RU-irina-medium, ru_RU-denis-medium,
+#                 ru_RU-dmitri-medium
 # Auto-downloads on first use. See https://github.com/rhasspy/piper/blob/master/VOICES.md
-TTS_VOICE=ru_RU-ruslan-medium
+TTS_VOICE_EN=en_US-amy-medium
+TTS_VOICE_RU=ru_RU-ruslan-medium
 
 # ── API CORS ────────────────────────────────────────────────────────────────
 # Comma-separated list of allowed origins, OR ["*"] for fully open (dev only).

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -205,7 +205,9 @@ services:
       - VLLM_BASE_URL=http://vllm:8000/v1
       - VLLM_MODEL=qwen2.5-7b
       - VLLM_API_KEY=${VLLM_API_KEY:?VLLM_API_KEY is required}
-      - TTS_VOICE=${TTS_VOICE:-ru_RU-ruslan-medium}
+      # Two voices loaded simultaneously; the agent picks per utterance.
+      - TTS_VOICE_EN=${TTS_VOICE_EN:-en_US-amy-medium}
+      - TTS_VOICE_RU=${TTS_VOICE_RU:-ru_RU-ruslan-medium}
       # Cache paths match the non-root user's home in the agent Dockerfile.
       - HF_HOME=/home/appuser/.cache/huggingface
       - PIPER_VOICES_DIR=/home/appuser/.cache/piper

--- a/services/agent/lang.py
+++ b/services/agent/lang.py
@@ -1,0 +1,85 @@
+"""Tiny language detector for routing TTS to the right Piper voice.
+
+We only support English and Russian today, so this is intentionally a
+hand-rolled cyrillic-vs-latin classifier rather than a heavyweight
+language-detection library:
+
+- Pure stdlib, ~5 microseconds per call → no impact on the latency budget.
+- Zero dependencies → no extra wheels to ship in the Docker image.
+- Deterministic on short LLM-streamed chunks (where probabilistic
+  detectors trained on full sentences tend to flip-flop).
+
+When we add a third language, swap this for `lingua` (or similar) and
+keep the same `detect_language(text, fallback)` signature.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+CYRILLIC_START = "\u0400"
+CYRILLIC_END = "\u04ff"
+
+
+class Language(str, Enum):
+    """Supported TTS output languages.
+
+    `str`-mixin so the value compares equal to "en" / "ru" — useful when
+    serialising into env vars, logs, or pipecat frame metadata.
+    """
+
+    EN = "en"
+    RU = "ru"
+
+
+def detect_language(text: str, fallback: Language = Language.EN) -> Language:
+    """Classify a text chunk as English or Russian.
+
+    Heuristic, in order of precedence:
+        1. Any Cyrillic character → Russian. (Mixed strings like
+           "Hello мир" route to the Russian voice; Piper RU pronounces
+           Latin filler reasonably and we'd rather err that way than
+           hand "мир" to a Russian-voice with English phonemes.)
+        2. Any Latin alphabet character → English.
+        3. Otherwise (punctuation, digits, whitespace only) → fallback.
+           This covers LLM-streamed chunks like "." or "  " that carry
+           no language signal of their own — the caller should pass the
+           previously-detected language as `fallback` so the chunk
+           routes to the same voice as its neighbours.
+    """
+    has_cyrillic = False
+    has_latin = False
+    for ch in text:
+        if CYRILLIC_START <= ch <= CYRILLIC_END:
+            has_cyrillic = True
+            break  # cyrillic wins immediately
+        if ("a" <= ch <= "z") or ("A" <= ch <= "Z"):
+            has_latin = True
+    if has_cyrillic:
+        return Language.RU
+    if has_latin:
+        return Language.EN
+    return fallback
+
+
+class LanguageRouter:
+    """Stateful wrapper around `detect_language`.
+
+    Remembers the last language it returned so that subsequent
+    language-signal-free chunks (punctuation, digits, whitespace)
+    inherit it instead of always defaulting to English. Pull this out
+    of the FrameProcessor so the routing logic can be unit-tested
+    without pipecat's frame machinery.
+    """
+
+    def __init__(self, default: Language = Language.EN) -> None:
+        self._last = default
+
+    @property
+    def last(self) -> Language:
+        return self._last
+
+    def route(self, text: str) -> Language:
+        """Detect the language of `text`, remember it, return it."""
+        self._last = detect_language(text, fallback=self._last)
+        return self._last

--- a/services/agent/main.py
+++ b/services/agent/main.py
@@ -60,17 +60,28 @@ async def run() -> None:
         room_name=room,
         vllm_base_url=require_env("VLLM_BASE_URL"),
         vllm_model=require_env("VLLM_MODEL", "qwen2.5-7b"),
-        tts_voice=require_env("TTS_VOICE", "ru_RU-ruslan-medium"),
+        tts_voice_en=require_env("TTS_VOICE_EN", "en_US-amy-medium"),
+        tts_voice_ru=require_env("TTS_VOICE_RU", "ru_RU-ruslan-medium"),
         vllm_api_key=require_env("VLLM_API_KEY", "not-used"),
     )
-    logger.info(f"Agent joining room={cfg.room_name} model={cfg.vllm_model} voice={cfg.tts_voice}")
+    logger.info(
+        "Agent joining room={room} model={model} en_voice={en} ru_voice={ru}",
+        room=cfg.room_name,
+        model=cfg.vllm_model,
+        en=cfg.tts_voice_en,
+        ru=cfg.tts_voice_ru,
+    )
 
     task, transport = build_task(cfg)
 
     @transport.event_handler("on_first_participant_joined")
     async def _on_join(_transport, participant_id):  # noqa: ANN001
         logger.info(f"Participant joined: {participant_id}")
-        # Short bilingual-friendly greeting. Adjust to taste per user locale.
+        # Bilingual greeting: two separate frames so the TTS router picks
+        # the right voice for each. The cyrillic-vs-latin classifier in
+        # services/agent/lang.py routes "Hi!" to en_voice and "Привет!"
+        # to ru_voice automatically.
+        await task.queue_frame(TTSSpeakFrame("Hi! How can I help you?"))
         await task.queue_frame(TTSSpeakFrame("Привет! Чем могу помочь?"))
 
     @transport.event_handler("on_participant_left")

--- a/services/agent/pipeline.py
+++ b/services/agent/pipeline.py
@@ -2,10 +2,18 @@
 
 Graph:
     LiveKit mic audio  →  Silero VAD  →  Faster-Whisper (GPU)  →
-    Qwen2.5-7B (vLLM)  →  Piper TTS (CPU, in-process)  →  LiveKit speaker
+    Qwen2.5-7B (vLLM)  →  Bilingual TTS router  →  LiveKit speaker
+                                       │
+                                       ├──→ Piper EN voice (CPU)
+                                       └──→ Piper RU voice (CPU)
 
 Everything streams. First audio out should land ~700ms after end-of-speech on
 the RTX 5080 / L4 target hardware.
+
+Whisper auto-detects language per utterance, the LLM is told to reply in the
+same language, and the TTS router below picks the matching Piper voice based
+on a cheap cyrillic-vs-latin classifier (see `lang.py`). Two voice models are
+loaded simultaneously (~50 MB each, CPU-resident).
 """
 
 from __future__ import annotations
@@ -14,6 +22,8 @@ from dataclasses import dataclass
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.audio.vad.vad_analyzer import VADParams
+from pipecat.frames.frames import Frame, TextFrame, TTSSpeakFrame
+from pipecat.pipeline.parallel_pipeline import ParallelPipeline
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.llm_context import LLMContext
@@ -22,11 +32,14 @@ from pipecat.processors.aggregators.llm_response_universal import (
     LLMUserAggregatorParams,
 )
 from pipecat.processors.audio.vad_processor import VADProcessor
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.services.piper.tts import PiperTTSService
 from pipecat.services.whisper.stt import Model as WhisperModel
 from pipecat.services.whisper.stt import WhisperSTTService
 from pipecat.transports.livekit.transport import LiveKitParams, LiveKitTransport
+
+from lang import Language, LanguageRouter
 
 SYSTEM_PROMPT = (
     "You are a helpful voice assistant. Your replies are spoken aloud, so: "
@@ -45,7 +58,10 @@ class AgentConfig:
     room_name: str
     vllm_base_url: str
     vllm_model: str
-    tts_voice: str  # e.g. "ru_RU-ruslan-medium"
+    # Two Piper voices, one per supported output language. Both are loaded
+    # at startup; the bilingual router below picks per utterance.
+    tts_voice_en: str  # e.g. "en_US-amy-medium"
+    tts_voice_ru: str  # e.g. "ru_RU-ruslan-medium"
     # vLLM doesn't authenticate by default, but the OpenAI client requires
     # a non-empty string. Override via VLLM_API_KEY when vLLM is fronted by
     # an auth proxy (e.g. an api gateway in prod).
@@ -53,6 +69,35 @@ class AgentConfig:
     whisper_model: WhisperModel = WhisperModel.LARGE_V3_TURBO
     whisper_device: str = "cuda"
     whisper_compute_type: str = "int8_float16"
+
+
+class LanguageFilter(FrameProcessor):
+    """Drops TextFrames / TTSSpeakFrames whose language doesn't match.
+
+    Sits at the head of one branch of a `ParallelPipeline`. Both branches
+    receive every frame; this filter drops anything destined for the
+    other branch's voice. Non-text frames (lifecycle, audio, control)
+    pass through unchanged so the downstream TTS can keep its state in
+    sync with the rest of the pipeline.
+
+    Stateful: short LLM-streamed chunks like "." or " " carry no language
+    signal of their own, so we remember the last detected language and
+    use it as the fallback. Both branches see the same frames in the
+    same order, so their states stay in lock-step.
+    """
+
+    def __init__(self, target: Language) -> None:
+        super().__init__()
+        self._target = target
+        self._router = LanguageRouter()
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, (TextFrame, TTSSpeakFrame)) and frame.text:
+            if self._router.route(frame.text) != self._target:
+                # Drop: this frame belongs to the other language's branch.
+                return
+        await self.push_frame(frame, direction)
 
 
 def build_task(cfg: AgentConfig) -> tuple[PipelineTask, LiveKitTransport]:
@@ -114,11 +159,15 @@ def build_task(cfg: AgentConfig) -> tuple[PipelineTask, LiveKitTransport]:
         ),
     )
 
-    tts = PiperTTSService(
-        settings=PiperTTSService.Settings(
-            voice=cfg.tts_voice,
-        ),
-        use_cuda=False,  # CPU is plenty for Piper; keep GPU for LLM + Whisper
+    # Two Piper voices, one per language. CPU-only — Piper is fast enough
+    # on CPU and we want to keep the GPU free for vLLM + Whisper.
+    tts_en = PiperTTSService(
+        settings=PiperTTSService.Settings(voice=cfg.tts_voice_en),
+        use_cuda=False,
+    )
+    tts_ru = PiperTTSService(
+        settings=PiperTTSService.Settings(voice=cfg.tts_voice_ru),
+        use_cuda=False,
     )
 
     context = LLMContext()
@@ -136,7 +185,15 @@ def build_task(cfg: AgentConfig) -> tuple[PipelineTask, LiveKitTransport]:
             stt,
             user_agg,
             llm,
-            tts,
+            # Bilingual TTS routing. Both branches receive every frame;
+            # each LanguageFilter drops the frames meant for the other
+            # voice, so only one Piper actually synthesises any given
+            # sentence. The merged audio comes out the other side and
+            # flows to transport.output() unchanged.
+            ParallelPipeline(
+                [LanguageFilter(Language.EN), tts_en],
+                [LanguageFilter(Language.RU), tts_ru],
+            ),
             transport.output(),
             assistant_agg,
         ]

--- a/services/agent/tests/test_lang.py
+++ b/services/agent/tests/test_lang.py
@@ -1,0 +1,114 @@
+"""Tests for the bilingual language detector and stateful router."""
+
+from __future__ import annotations
+
+import pytest
+
+from lang import Language, LanguageRouter, detect_language
+
+
+class TestDetectLanguage:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Hello",
+            "Hello, how are you?",
+            "I'm doing well, thanks.",
+            "I",  # single letter
+            "OK",
+            "The quick brown fox",
+        ],
+    )
+    def test_pure_english(self, text: str) -> None:
+        assert detect_language(text) == Language.EN
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Привет",
+            "Привет, как дела?",
+            "Спасибо, всё хорошо.",
+            "Я",  # single letter
+            "Расскажи мне сказку",
+        ],
+    )
+    def test_pure_russian(self, text: str) -> None:
+        assert detect_language(text) == Language.RU
+
+    def test_mixed_routes_to_russian(self) -> None:
+        # Any cyrillic char → RU. Russian Piper handles latin filler
+        # better than English Piper handles cyrillic.
+        assert detect_language("Hello, мир") == Language.RU
+        assert detect_language("привет world") == Language.RU
+        assert detect_language("foo бар baz") == Language.RU
+
+    @pytest.mark.parametrize(
+        "text",
+        ["", " ", ".", "...", "!?", "  \n  ", "123", "$5.00"],
+    )
+    def test_no_signal_uses_fallback(self, text: str) -> None:
+        # No alphabetic content → use the caller-supplied fallback.
+        assert detect_language(text, fallback=Language.EN) == Language.EN
+        assert detect_language(text, fallback=Language.RU) == Language.RU
+
+    def test_default_fallback_is_english(self) -> None:
+        assert detect_language(".") == Language.EN
+        assert detect_language("") == Language.EN
+
+    def test_digits_alone_use_fallback(self) -> None:
+        assert detect_language("42", fallback=Language.RU) == Language.RU
+        assert detect_language("3.14159", fallback=Language.EN) == Language.EN
+
+    def test_language_string_value(self) -> None:
+        # str-mixin: enum members are usable wherever a plain string is
+        # expected (env vars, frame metadata, log lines).
+        assert Language.EN == "en"
+        assert Language.RU == "ru"
+
+
+class TestLanguageRouter:
+    def test_starts_in_english(self) -> None:
+        r = LanguageRouter()
+        assert r.last == Language.EN
+
+    def test_default_overrideable(self) -> None:
+        r = LanguageRouter(default=Language.RU)
+        assert r.last == Language.RU
+
+    def test_pure_english_stream(self) -> None:
+        r = LanguageRouter()
+        for chunk in ["Hello", ", ", "how", " are", " you", "?"]:
+            assert r.route(chunk) == Language.EN
+        assert r.last == Language.EN
+
+    def test_pure_russian_stream(self) -> None:
+        r = LanguageRouter()
+        for chunk in ["Привет", ", ", "как", " дела", "?"]:
+            assert r.route(chunk) == Language.RU
+        assert r.last == Language.RU
+
+    def test_punctuation_inherits_previous(self) -> None:
+        # Realistic LLM streaming pattern: words then a separate "."
+        # frame. The "." has no language signal of its own — it should
+        # follow whichever language the surrounding tokens were.
+        r = LanguageRouter()
+        assert r.route("Привет") == Language.RU
+        assert r.route(".") == Language.RU  # inherits RU
+        assert r.route("Hello") == Language.EN
+        assert r.route(".") == Language.EN  # now inherits EN
+
+    def test_language_switch_mid_stream(self) -> None:
+        # The agent answers an EN question, then a RU one. State
+        # transitions cleanly without leaking the previous language.
+        r = LanguageRouter()
+        assert r.route("I'm doing well.") == Language.EN
+        assert r.route("Спасибо!") == Language.RU
+        assert r.route("...") == Language.RU
+        assert r.route("Sure!") == Language.EN
+
+    def test_independent_routers_dont_share_state(self) -> None:
+        a = LanguageRouter()
+        b = LanguageRouter()
+        a.route("Привет")
+        assert a.last == Language.RU
+        assert b.last == Language.EN  # unchanged


### PR DESCRIPTION
## The bug

The system prompt told the LLM to reply bilingually:
> If the user speaks Russian, reply in Russian. If the user speaks English, reply in English.

…but only one Piper voice was loaded (`TTS_VOICE=ru_RU-ruslan-medium` by default), so English replies were spoken with a Russian voice — phonetically mangled and often unintelligible.

## The fix

Two `PiperTTSService` instances loaded simultaneously, wrapped in `pipecat.pipeline.parallel_pipeline.ParallelPipeline`. A `LanguageFilter` at the head of each branch drops frames whose detected language doesn't match the branch's voice.

```
LLM → ParallelPipeline(
        [LanguageFilter(EN), tts_en],   # only EN frames reach this branch
        [LanguageFilter(RU), tts_ru],   # only RU frames reach this branch
      ) → transport.output()
```

### Language detection (`services/agent/lang.py`)

Hand-rolled cyrillic-vs-latin classifier — no extra dependency, ~5µs per call:

1. Any Cyrillic char → Russian (mixed strings like "Hello мир" route to Russian — Piper RU pronounces Latin filler better than English Piper handles Cyrillic)
2. Any Latin alpha char → English
3. Otherwise → fallback (e.g. previous language for streamed LLM chunks like ".")

`LanguageRouter` is the stateful wrapper: it remembers the last detected language so streamed LLM tokens like "I'm" → " doing" → "." → " well" all route to the same voice.

## Changes

- **new** `services/agent/lang.py` — `Language` enum, `detect_language()`, `LanguageRouter`
- **new** `services/agent/tests/test_lang.py` — 24 tests covering detector + router (streaming, punctuation inheritance, mid-conversation language switch)
- `services/agent/pipeline.py` — `LanguageFilter` FrameProcessor, two TTS instances, `ParallelPipeline` wiring
- `services/agent/main.py` — `TTS_VOICE_EN` + `TTS_VOICE_RU` env vars, bilingual greeting (two `TTSSpeakFrame`s, one per language; the router picks the right voice for each)
- `services/agent/pipeline.py` — `AgentConfig.tts_voice` split into `tts_voice_en` + `tts_voice_ru`
- `infra/.env.example` + `infra/docker-compose.yml` — `TTS_VOICE` → `TTS_VOICE_EN` + `TTS_VOICE_RU`

## Tests

**36/36 agent tests pass** (was 6, now 6 env + 30 lang). New cases include:

- Pure English / pure Russian streams
- Mixed-language sentences ("Hello, мир")
- Punctuation inheriting the previous language ("Привет" → "." → still RU)
- Language switching mid-stream (EN response → RU response → EN response)
- Independent routers don't share state

## Latency impact

None measurable. Detection is a pure-Python comprehension over the chars of one chunk — sub-microsecond. Two Piper models in CPU memory at ~50 MB each. GPU is untouched.

## Migration notes

Existing `.env` files using `TTS_VOICE=...` will no longer work — Compose now requires `TTS_VOICE_EN` and `TTS_VOICE_RU`. Defaults are sensible (`en_US-amy-medium` and `ru_RU-ruslan-medium`) so omitting both is fine for the standard demo case.