### PR TITLE
fix(ci): rename unused loop var to satisfy shellcheck SC2034

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
             -e LIVEKIT_API_SECRET=ci-test-secret-min-32-chars-long-xx \
             -e LIVEKIT_URL=ws://localhost:7880 \
             project-800ms-api:ci
-          for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+          for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
             if curl -fsS http://localhost:8000/health; then
               echo
               echo "api is healthy"


### PR DESCRIPTION
The api smoke-test loop in \`docker-api\` never references its iteration variable. The shellcheck version bundled with actionlint on ubuntu-latest fires SC2034 (\`i appears unused\`):

\`\`\`
.github/workflows/ci.yml:136:9: shellcheck reported issue in this script:
SC2034:warning:7:1: i appears unused. Verify use (or export if used externally)
\`\`\`

My local actionlint ships an older shellcheck that doesn't catch it, which is why local pre-commit was green and CI was red.

Fix: rename \`i\` → \`_\`. Universally treated as 'intentionally unused' by every shellcheck version. Zero behavioural change.

## Unblocks

- #8 chore(api): bump python from 3.12 to 3.14
- #9 feat(agent): bilingual TTS routing (EN+RU)
- #2, #4, #5, #6, #7 (all the dependabot PRs)

After merge, I'll \`@dependabot rebase\` the dependabot PRs and \`gh pr update-branch\` mine.