### PR TITLE
ci: trigger on merge_group events for GitHub Merge Queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Run on GitHub Merge Queue's speculative branches. Without this, the
+  # merge queue can't gate PRs because no required status checks would
+  # ever start. The same jobs run for both pull_request and merge_group
+  # events — branch protection looks at status check NAMES, not events.
+  merge_group:
   workflow_dispatch:
 
 # Cancel in-flight runs on the same ref when a new commit arrives.


### PR DESCRIPTION
Step 1 of enabling [GitHub Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) on \`main\` to eliminate the rebase races we hit during today's Dependabot batch.

## What this changes

Adds \`merge_group\` to the \`on:\` triggers in \`.github/workflows/ci.yml\`. The same 8 status checks now run on:
- \`pull_request\` events (as before — gates the PR itself)
- \`merge_group\` events (new — gates the merge queue's speculative branches)

Branch protection looks at status check **names**, so the same 8 contexts cover both event types — no changes to the protection rule yet.

## Why this is step 1

Merge queue can't gate PRs unless required status checks fire on \`merge_group\` events. If we enabled the queue without this trigger, PRs would sit in the queue forever waiting for checks that never start.

## Step 2 (after this lands)

\`\`\`bash
gh api -X PUT /repos/gofrolist/project-800ms/branches/main/protection --input <payload>
\`\`\`

with \`strict: false\` (the queue makes 'branches must be up to date' obsolete) and \`merge_queue\` enabled.

## Background

During today's Dependabot batch (8 PRs across 6 ecosystems) we burned ~30 minutes on rebase races: each PR auto-merge invalidated the others under \`strict: true\`, so each one had to be rebased + CI re-run multiple times before its turn came. Merge queue handles this natively by batching PRs and running CI once on the speculative merged result.