### PR TITLE
feat(web,api,agent): per-session TTS engine selector

### DIFF
--- a/apps/api/routes/sessions.py
+++ b/apps/api/routes/sessions.py
@@ -122,6 +122,8 @@ async def _dispatch_agent(room: str, body: CreateSessionRequest) -> None:
         payload["llm_model"] = body.llm_model
     if body.context is not None:
         payload["context"] = body.context
+    if body.tts_engine is not None:
+        payload["tts_engine"] = body.tts_engine
 
     async with httpx.AsyncClient(timeout=10) as client:
         try:

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -7,9 +7,15 @@ code review.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+
+# Whitelisted TTS engines the agent knows how to dispatch. Mirrors
+# services/agent/overrides.py::_VALID_TTS_ENGINES and pipeline.py's
+# _VALID_TTS_ENGINES — kept in sync by hand because the API and agent
+# live in separate Python environments (3.14 vs 3.12).
+TtsEngine = Literal["piper", "silero", "qwen3"]
 
 
 class CreateSessionRequest(BaseModel):
@@ -59,6 +65,15 @@ class CreateSessionRequest(BaseModel):
     context: dict[str, Any] | None = Field(
         default=None,
         description="Arbitrary game-state context passed to the agent.",
+    )
+    tts_engine: TtsEngine | None = Field(
+        default=None,
+        description=(
+            "TTS engine for this session — one of 'piper', 'silero', 'qwen3'. "
+            "Falls back to the agent's TTS_ENGINE env default when omitted. "
+            "Used by the demo site's three-button selector to route each "
+            "session to a different backend without restarting the agent."
+        ),
     )
 
 

--- a/apps/api/tests/test_v1_sessions.py
+++ b/apps/api/tests/test_v1_sessions.py
@@ -142,6 +142,47 @@ async def test_create_session_forwards_payload_to_agent(client, seed_tenant, age
     assert "context" not in dispatched
 
 
+async def test_create_session_forwards_tts_engine_to_agent(client, seed_tenant, agent_stub):
+    """Three-button demo contract: POST /v1/sessions with tts_engine flows
+    through the dispatch payload so the agent can pick the right TTS
+    backend per-session."""
+    _tenant, raw_key = seed_tenant
+    for engine in ("piper", "silero", "qwen3"):
+        agent_stub.post.reset_mock()
+        r = await client.post(
+            "/v1/sessions",
+            headers={"X-API-Key": raw_key},
+            json={"tts_engine": engine},
+        )
+        assert r.status_code == 201, r.text
+        dispatched = agent_stub.post.await_args.kwargs["json"]
+        assert dispatched["tts_engine"] == engine
+
+
+async def test_create_session_omits_tts_engine_when_unset(client, seed_tenant, agent_stub):
+    """Empty body must NOT inject tts_engine — the agent's TTS_ENGINE env
+    default has to win when the client is silent about engine choice."""
+    _tenant, raw_key = seed_tenant
+    r = await client.post("/v1/sessions", headers={"X-API-Key": raw_key}, json={})
+    assert r.status_code == 201
+    dispatched = agent_stub.post.await_args.kwargs["json"]
+    assert "tts_engine" not in dispatched
+
+
+async def test_create_session_rejects_unknown_tts_engine(client, seed_tenant, agent_stub):
+    """Pydantic Literal validation refuses unknown engine values BEFORE
+    the dispatch call — keeps bogus strings from ever reaching the agent."""
+    _tenant, raw_key = seed_tenant
+    r = await client.post(
+        "/v1/sessions",
+        headers={"X-API-Key": raw_key},
+        json={"tts_engine": "bogus"},
+    )
+    assert r.status_code == 422
+    assert r.json()["error"]["code"] == "validation_error"
+    assert agent_stub.post.await_count == 0
+
+
 async def test_create_session_rejects_unknown_fields(client, seed_tenant, agent_stub):
     _tenant, raw_key = seed_tenant
     r = await client.post(

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,12 +11,21 @@ import {
 const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
 const API_KEY = import.meta.env.VITE_API_KEY ?? "";
 
+type TtsEngine = "piper" | "silero" | "qwen3";
+
+const TTS_ENGINES: readonly { id: TtsEngine; label: string; sub: string }[] = [
+  { id: "piper", label: "Piper", sub: "CPU · baseline" },
+  { id: "silero", label: "Silero", sub: "GPU · v5 RU" },
+  { id: "qwen3", label: "Qwen3", sub: "GPU · 0.6B" },
+] as const;
+
 interface Session {
   session_id: string;
   url: string;
   token: string;
   room: string;
   identity: string;
+  tts_engine: TtsEngine;
 }
 
 interface ErrorEnvelope {
@@ -46,7 +55,7 @@ async function parseError(res: Response): Promise<string> {
   return `API ${res.status}`;
 }
 
-async function createSession(): Promise<Session> {
+async function createSession(ttsEngine: TtsEngine): Promise<Session> {
   if (!API_KEY) {
     throw new Error(
       "VITE_API_KEY is not configured. Set it at build time or via the web container's API_KEY env.",
@@ -58,31 +67,35 @@ async function createSession(): Promise<Session> {
       "Content-Type": "application/json",
       "X-API-Key": API_KEY,
     },
-    // Empty body uses tenant / agent defaults. Add user_id / npc_id /
-    // persona here when wiring this SPA into a game that has a current
-    // character context.
-    body: "{}",
+    body: JSON.stringify({ tts_engine: ttsEngine }),
   });
   if (!res.ok) {
     throw new Error(await parseError(res));
   }
-  return (await res.json()) as Session;
+  const data = (await res.json()) as Omit<Session, "tts_engine">;
+  // /v1/sessions doesn't echo back tts_engine; carry the client's choice
+  // through so the CallView can surface which engine is speaking.
+  return { ...data, tts_engine: ttsEngine };
 }
 
 export function App() {
   const [session, setSession] = useState<Session | null>(null);
   const [status, setStatus] = useState<Status>("idle");
+  const [pendingEngine, setPendingEngine] = useState<TtsEngine | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const startCall = useCallback(async () => {
+  const startCall = useCallback(async (engine: TtsEngine) => {
     setStatus("connecting");
+    setPendingEngine(engine);
     setError(null);
     try {
-      setSession(await createSession());
+      setSession(await createSession(engine));
       setStatus("live");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setStatus("error");
+    } finally {
+      setPendingEngine(null);
     }
   }, []);
 
@@ -106,7 +119,7 @@ export function App() {
       >
         <RoomAudioRenderer />
         <StartAudio label="Click to enable audio" />
-        <CallView onEnd={endCall} identity={session.identity} />
+        <CallView onEnd={endCall} identity={session.identity} ttsEngine={session.tts_engine} />
       </LiveKitRoom>
     );
   }
@@ -114,15 +127,35 @@ export function App() {
   return (
     <div className="app">
       <h1>project-800ms</h1>
-      <button className="start-btn" onClick={startCall} disabled={status === "connecting"}>
-        {status === "connecting" ? "Connecting…" : "Start call"}
-      </button>
+      <p className="subtitle">Pick a TTS engine to start a call.</p>
+      <div className="engine-picker">
+        {TTS_ENGINES.map((engine) => {
+          const isPending = pendingEngine === engine.id && status === "connecting";
+          return (
+            <button
+              key={engine.id}
+              className="engine-btn"
+              onClick={() => startCall(engine.id)}
+              disabled={status === "connecting"}
+            >
+              <span className="engine-label">{isPending ? "Connecting…" : engine.label}</span>
+              <span className="engine-sub">{engine.sub}</span>
+            </button>
+          );
+        })}
+      </div>
       {error && <div className="status error">Error: {error}</div>}
     </div>
   );
 }
 
-function CallView({ onEnd, identity }: { onEnd: () => void; identity: string }) {
+interface CallViewProps {
+  onEnd: () => void;
+  identity: string;
+  ttsEngine: TtsEngine;
+}
+
+function CallView({ onEnd, identity, ttsEngine }: CallViewProps) {
   const { state, audioTrack } = useVoiceAssistant();
   const [messages, setMessages] = useState<Message[]>([]);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -158,7 +191,8 @@ function CallView({ onEnd, identity }: { onEnd: () => void; identity: string }) 
         ))}
       </div>
       <div className="status">
-        you: <code>{identity}</code> · assistant: <code>{state}</code>
+        you: <code>{identity}</code> · tts: <code>{ttsEngine}</code> · assistant:{" "}
+        <code>{state}</code>
       </div>
       <button
         className="start-btn"

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -47,6 +47,63 @@ body {
   cursor: not-allowed;
 }
 
+.subtitle {
+  color: #9ca3af;
+  font-size: 0.95rem;
+  margin: -0.5rem 0 1.5rem;
+}
+
+.engine-picker {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.engine-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 9rem;
+  background: #1f2937;
+  color: white;
+  border: 1px solid #374151;
+  padding: 1rem 1.5rem;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: transform 0.1s ease, background 0.1s ease, border-color 0.1s ease;
+}
+
+.engine-btn:hover:not(:disabled) {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.engine-btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.engine-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.engine-label {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.engine-sub {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.engine-btn:hover:not(:disabled) .engine-sub {
+  color: #bfdbfe;
+}
+
 .status {
   margin-top: 1rem;
   font-size: 0.9rem;

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -37,12 +37,22 @@ VLLM_API_KEY=REPLACE_ME_openssl_rand_hex_32
 HUGGING_FACE_HUB_TOKEN=
 
 # ── TTS engine selector ─────────────────────────────────────────────────────
-# Which TTS implementation the agent pipeline uses. "piper" (default) is the
-# local CPU-bound Piper synthesis wired today. "silero" and "qwen3" branches
-# are added by services/agent/tts_factory.py in later units of the TTS
-# abstraction plan (docs/plans/2026-04-21-001-*). Unknown values raise
-# ValueError at pipeline build time.
+# Fallback TTS engine when a session does NOT set `tts_engine` on
+# POST /v1/sessions. "piper" (CPU, default), "silero" (GPU), "qwen3"
+# (sidecar GPU). Per-session overrides from the API take precedence, so
+# the demo site's three-button selector can route each call to a
+# different backend without restarting the agent.
 TTS_ENGINE=piper
+
+# Comma-separated list of engines to pre-load at agent startup. Silero is
+# the only engine with an agent-side preload cost (torch.hub model fetch
+# ~200 MB); listing it here makes Silero-backed sessions ready immediately.
+# Piper loads lazily, Qwen3 lives in the sidecar container. Defaults to
+# the TTS_ENGINE value so single-engine operators keep old behavior. For
+# the three-button demo, set:
+#   TTS_PRELOAD_ENGINES=piper,silero,qwen3
+#   COMPOSE_PROFILES=local-llm,tts-qwen3
+TTS_PRELOAD_ENGINES=piper
 
 # ── TTS voice (Piper) ───────────────────────────────────────────────────────
 # Russian Piper voice for TTS output. Auto-downloads on first use.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -315,14 +315,23 @@ services:
       - VLLM_API_KEY=${LLM_API_KEY:?LLM_API_KEY is required}
       - TTS_VOICE=${TTS_VOICE:-ru_RU-denis-medium}
       # TTS engine selector — one of "piper" (default), "silero", "qwen3".
-      # Must be wired through compose or the agent container never sees
-      # env-file edits. The agent's AgentConfig validates the value at
-      # construction time (services/agent/pipeline.py:AgentConfig).
+      # Session-level overrides from POST /v1/sessions.tts_engine take
+      # precedence (see services/agent/overrides.py); this env is the
+      # fallback when a session omits the field. The agent's AgentConfig
+      # validates the value at construction time.
       - TTS_ENGINE=${TTS_ENGINE:-piper}
-      # Qwen3-TTS sidecar endpoint + API key. Only read when
-      # TTS_ENGINE=qwen3; the agent factory raises ValueError if either
-      # is empty at dispatch time (services/agent/tts_factory.py). Leave
-      # unset on Piper / Silero deploys.
+      # Comma-separated list of engines to pre-load at agent startup.
+      # Silero is the only engine with an agent-side preload (torch.hub
+      # model fetch); listing "silero" here makes Silero-backed sessions
+      # ready without a cold-load on first dispatch. Defaults to
+      # TTS_ENGINE so single-engine operators keep their old behavior.
+      # Demo deployments with the three-button selector set
+      # TTS_PRELOAD_ENGINES=piper,silero,qwen3.
+      - TTS_PRELOAD_ENGINES=${TTS_PRELOAD_ENGINES:-${TTS_ENGINE:-piper}}
+      # Qwen3-TTS sidecar endpoint + API key. Required when any session
+      # may select TTS_ENGINE=qwen3 — the factory raises ValueError at
+      # dispatch time if either is empty. Leave unset on Piper/Silero-only
+      # deploys.
       - QWEN3_TTS_BASE_URL=${QWEN3_TTS_BASE_URL:-}
       - QWEN3_TTS_API_KEY=${QWEN3_TTS_API_KEY:-}
       - HF_HOME=/home/appuser/.cache/huggingface
@@ -367,6 +376,14 @@ services:
       # LLM_BASE_URL), vllm is skipped and this dependency is ignored.
       # Requires docker compose >= 2.20 for `required: false`.
       vllm:
+        condition: service_healthy
+        required: false
+      # Optional — only materializes when the `tts-qwen3` profile is
+      # active. For deploys that expose Qwen3 through /v1/sessions, wait
+      # for the sidecar's /health to pass before accepting traffic so the
+      # first Qwen3-engine session isn't served against a cold model. With
+      # the profile off, compose ignores the dependency entirely.
+      qwen3-tts:
         condition: service_healthy
         required: false
 

--- a/services/agent/main.py
+++ b/services/agent/main.py
@@ -179,11 +179,25 @@ def main() -> None:
         logger.exception("GigaAM pre-load failed — refusing to start agent")
         sys.exit(3)
 
-    # Conditional Silero pre-load. Only pay the torch.hub download +
-    # GPU-bind cost when Silero is the active engine — otherwise Piper
-    # and Qwen3 deployments would eat an unnecessary ~200 MB download
-    # and warm-start delay. Same hard-fail semantics as GigaAM above.
-    if _base_config["tts_engine"] == "silero":
+    # Conditional Silero pre-load. The `TTS_PRELOAD_ENGINES` env var is a
+    # comma-separated list of engines the agent should be ready to serve
+    # per-session (see PerSessionOverrides.tts_engine). Silero is the only
+    # engine with an agent-side preload cost — Piper has none (loaded
+    # lazily inside PiperTTSService) and Qwen3's model lives in the
+    # sidecar container. Default: `TTS_ENGINE`'s value, preserving the
+    # single-engine operator workflow. Set `TTS_PRELOAD_ENGINES=piper,silero,qwen3`
+    # when the demo site's three-button selector needs all three ready
+    # without a cold-load on first dispatch. Same hard-fail semantics as
+    # GigaAM above.
+    preload_engines = {
+        e.strip()
+        for e in os.environ.get(
+            "TTS_PRELOAD_ENGINES",
+            str(_base_config["tts_engine"]),
+        ).split(",")
+        if e.strip()
+    }
+    if "silero" in preload_engines:
         try:
             load_silero()
         except Exception:  # noqa: BLE001 — intentional hard-fail at startup

--- a/services/agent/overrides.py
+++ b/services/agent/overrides.py
@@ -50,6 +50,11 @@ DEFAULT_GREETINGS_BY_LANGUAGE: dict[str, str] = {
 
 DEFAULT_LANGUAGE = "ru"
 
+# Mirrors pipeline._VALID_TTS_ENGINES; duplicated here so parsing the
+# dispatch body doesn't require importing pipeline (which pulls in
+# pipecat + CUDA on the import path).
+_VALID_TTS_ENGINES: frozenset[str] = frozenset({"piper", "silero", "qwen3"})
+
 
 @dataclass(frozen=True)
 class PerSessionOverrides:
@@ -62,6 +67,12 @@ class PerSessionOverrides:
     user_id: str | None = None
     npc_id: str | None = None
     context: dict[str, Any] | None = None
+    # When set, selects the TTS engine for this session. Validated against
+    # the same whitelist used by pipeline.AgentConfig; unknown or empty
+    # values are dropped (fall back to cfg.tts_engine). This is how the
+    # /demo site's three-button selector routes each session to a
+    # different backend without restarting the agent.
+    tts_engine: str | None = None
 
     @classmethod
     def from_dispatch(cls, body: dict[str, Any]) -> PerSessionOverrides:
@@ -73,6 +84,16 @@ class PerSessionOverrides:
         def _as_dict(value: Any) -> dict[str, Any] | None:
             return value if isinstance(value, dict) and value else None
 
+        def _as_tts_engine(value: Any) -> str | None:
+            # Drop unknown values silently rather than raising — the factory
+            # still raises ValueError on unknown engine names, but the API
+            # validates first so anything reaching here should already be in
+            # the whitelist. Defense-in-depth: a misbehaving client can't
+            # crash the agent by sending a bogus engine string.
+            if isinstance(value, str) and value in _VALID_TTS_ENGINES:
+                return value
+            return None
+
         return cls(
             persona=_as_dict(body.get("persona")),
             voice=_as_str(body.get("voice")),
@@ -81,6 +102,7 @@ class PerSessionOverrides:
             user_id=_as_str(body.get("user_id")),
             npc_id=_as_str(body.get("npc_id")),
             context=_as_dict(body.get("context")),
+            tts_engine=_as_tts_engine(body.get("tts_engine")),
         )
 
     @property

--- a/services/agent/pipeline.py
+++ b/services/agent/pipeline.py
@@ -94,6 +94,12 @@ def build_task(
     language = overrides.effective_language
     voice = overrides.voice or cfg.tts_voice
     llm_model = overrides.llm_model or cfg.vllm_model
+    # Per-session engine override (from the demo site's three-button
+    # selector). Falls back to cfg.tts_engine (from TTS_ENGINE env) when
+    # unset. overrides.tts_engine is already whitelist-validated in
+    # PerSessionOverrides.from_dispatch, so the factory branch below never
+    # sees a bogus engine value from a client.
+    tts_engine = overrides.tts_engine or cfg.tts_engine
     system_instruction = build_system_prompt(overrides.persona, language)
 
     transport = LiveKitTransport(
@@ -136,7 +142,7 @@ def build_task(
         ),
     )
 
-    tts = build_tts_service(cfg.tts_engine, cfg=cfg, voice=voice)
+    tts = build_tts_service(tts_engine, cfg=cfg, voice=voice)
 
     context = LLMContext()
     user_agg, assistant_agg = LLMContextAggregatorPair(

--- a/services/agent/tests/test_overrides.py
+++ b/services/agent/tests/test_overrides.py
@@ -61,6 +61,26 @@ class TestFromDispatch:
         assert o.persona is None
         assert o.context is None
 
+    def test_tts_engine_accepts_whitelist(self) -> None:
+        for engine in ("piper", "silero", "qwen3"):
+            o = PerSessionOverrides.from_dispatch({"tts_engine": engine})
+            assert o.tts_engine == engine
+
+    def test_tts_engine_rejects_unknown_value(self) -> None:
+        """Defense-in-depth: the factory still raises ValueError on unknown
+        engines, but dropping here prevents an unsanitized client string
+        from reaching the pipeline construction at all."""
+        o = PerSessionOverrides.from_dispatch({"tts_engine": "bogus"})
+        assert o.tts_engine is None
+
+    def test_tts_engine_rejects_non_string(self) -> None:
+        o = PerSessionOverrides.from_dispatch({"tts_engine": 42})
+        assert o.tts_engine is None
+
+    def test_tts_engine_missing_yields_none(self) -> None:
+        o = PerSessionOverrides.from_dispatch({})
+        assert o.tts_engine is None
+
 
 class TestBuildSystemPrompt:
     def test_no_persona_returns_rules(self) -> None:


### PR DESCRIPTION
## Summary

Replaces the single **Start call** button on [coastalai.ai](https://coastalai.ai) with three buttons (Piper / Silero / Qwen3). Each button POSTs `/v1/sessions` with `{tts_engine: ...}` and the agent routes that session to the selected backend, without a process restart.

Lets the team run the R21 blind-listen protocol against the real pipeline instead of the offline synth corpus, and lets demo-site visitors A/B the engines side-by-side.

## Surfaces

- **apps/web** — three engine-select buttons, CallView shows the engine speaking.
- **apps/api** — `CreateSessionRequest.tts_engine: Literal['piper','silero','qwen3'] | None`; forwarded in the dispatch payload only when set.
- **services/agent** — `PerSessionOverrides.tts_engine` parses + whitelists; `build_task` resolves as `overrides.tts_engine or cfg.tts_engine`. `TTS_PRELOAD_ENGINES` env gates Silero preload (only engine with agent-side preload cost).
- **infra** — `agent.depends_on.qwen3-tts` with `required: false`; `.env.example` documents the demo-deployment recipe.

## Default behavior preserved

- `TTS_ENGINE=piper` (default) is the fallback when a session omits `tts_engine`.
- Single-engine operators keep old behavior — `TTS_PRELOAD_ENGINES` defaults to `TTS_ENGINE`'s value.
- Silero preload stays opt-in; demo deploy explicitly sets `TTS_PRELOAD_ENGINES=piper,silero,qwen3`.

## Demo deployment (coastalai.ai)

```env
COMPOSE_PROFILES=local-llm,tts-qwen3
TTS_PRELOAD_ENGINES=piper,silero,qwen3
```

## Test plan

- [x] Agent: 4 new override tests (whitelist accept, drops bogus, drops non-strings, None when missing)
- [x] API: 3 new session tests (forwarded for each engine, omitted when unset, 422 on unknown)
- [x] Full agent test suite: **112 passed**
- [x] Full API test suite: **126 passed**
- [x] Web bundle builds clean
- [x] Pre-commit hooks green
- [ ] Manual: deploy to GCP, smoke-test each of the three buttons