### PR TITLE
ci(retriever): publish retriever image to GHCR + prod overlay entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,8 +598,18 @@ jobs:
       # Import-smoke the app entrypoint. The base image already smokes
       # core deps; this catches any source-level import breakage (missing
       # module, circular import, syntax error in main.py).
+      #
+      # `import main` triggers `create_app()` → `get_settings()`, so we
+      # stub the required Settings env vars. The values are intentionally
+      # invalid-looking — the smoke exercises the import graph + Settings
+      # validation, not real connectivity.
       - name: Smoke-test retriever app import
         run: |
           IMAGE_TAG=$(echo "${{ steps.meta-retriever.outputs.tags }}" | head -n 1)
           echo "Smoke-testing ${IMAGE_TAG}"
-          docker run --rm --entrypoint python "${IMAGE_TAG}" -c "import main; print('retriever app import OK')"
+          docker run --rm \
+            -e DB_URL=postgresql+asyncpg://stub:stub@stub:5432/stub \
+            -e LLM_BASE_URL=http://stub.invalid \
+            -e LLM_API_KEY=stub \
+            -e REWRITER_MODEL=stub \
+            --entrypoint python "${IMAGE_TAG}" -c "import main; print('retriever app import OK')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
     outputs:
       api: ${{ steps.filter.outputs.api }}
       agent: ${{ steps.filter.outputs.agent }}
+      retriever: ${{ steps.filter.outputs.retriever }}
       web: ${{ steps.filter.outputs.web }}
       workflow: ${{ steps.filter.outputs.workflow }}
     steps:
@@ -57,6 +58,8 @@ jobs:
               - 'apps/api/**'
             agent:
               - 'services/agent/**'
+            retriever:
+              - 'services/retriever/**'
             web:
               - 'apps/web/**'
             workflow:
@@ -492,3 +495,111 @@ jobs:
           IMAGE_TAG=$(echo "${{ steps.meta-agent.outputs.tags }}" | head -n 1)
           echo "Smoke-testing ${IMAGE_TAG}"
           docker run --rm --entrypoint python "${IMAGE_TAG}" -c "from TTS.api import TTS; print('coqui-tts import OK')"
+
+  # ─── Docker: retriever (services/retriever) ──────────────────────────────
+  # Mirrors docker-agent's two-stage pattern (base + app). The retriever's
+  # base image carries CUDA + sentence-transformers + pgvector client
+  # (~3–4 GB) and is rebuilt only when pyproject.toml / uv.lock change.
+  # The app image is a thin COPY on top.
+  docker-retriever:
+    name: Docker build (services/retriever)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.retriever == 'true' || needs.changes.outputs.workflow == 'true'
+    permissions:
+      contents: read
+      packages: write
+    services:
+      registry:
+        image: registry:3
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet \
+                      /usr/local/lib/android \
+                      /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af || true
+          df -h
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+        with:
+          driver-opts: network=host
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build retriever-base image (CI handoff to local registry)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: services/retriever
+          file: services/retriever/Dockerfile.base
+          push: true
+          tags: localhost:5000/project-800ms-retriever-base:ci
+          cache-from: type=gha,scope=retriever-base
+          cache-to: type=gha,scope=retriever-base,mode=max
+
+      - name: Compute retriever-base image tags (GHCR)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: meta-retriever-base
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/project-800ms-retriever-base
+          tags: |
+            type=raw,value=latest
+            type=raw,value=main
+            type=sha,format=short
+
+      - name: Push retriever-base image to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: services/retriever
+          file: services/retriever/Dockerfile.base
+          push: true
+          tags: ${{ steps.meta-retriever-base.outputs.tags }}
+          labels: ${{ steps.meta-retriever-base.outputs.labels }}
+          cache-from: type=gha,scope=retriever-base
+
+      - name: Compute retriever image tags
+        id: meta-retriever
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/project-800ms-retriever
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,format=short
+
+      - name: Build retriever image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: services/retriever
+          load: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          build-args: |
+            BASE_IMAGE=localhost:5000/project-800ms-retriever-base:ci
+          tags: ${{ steps.meta-retriever.outputs.tags }}
+          labels: ${{ steps.meta-retriever.outputs.labels }}
+          cache-from: type=gha,scope=retriever
+          cache-to: type=gha,scope=retriever,mode=max
+
+      # Import-smoke the app entrypoint. The base image already smokes
+      # core deps; this catches any source-level import breakage (missing
+      # module, circular import, syntax error in main.py).
+      - name: Smoke-test retriever app import
+        run: |
+          IMAGE_TAG=$(echo "${{ steps.meta-retriever.outputs.tags }}" | head -n 1)
+          echo "Smoke-testing ${IMAGE_TAG}"
+          docker run --rm --entrypoint python "${IMAGE_TAG}" -c "import main; print('retriever app import OK')"

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -33,3 +33,8 @@ services:
     image: ghcr.io/gofrolist/project-800ms-agent:${IMAGE_TAG:-latest}
     build: !reset null
     pull_policy: always
+
+  retriever:
+    image: ghcr.io/gofrolist/project-800ms-retriever:${IMAGE_TAG:-latest}
+    build: !reset null
+    pull_policy: always

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -474,7 +474,9 @@ services:
     build:
       context: ../services/retriever
       args:
-        BASE_IMAGE: project-800ms-retriever-base:local
+        # Override RETRIEVER_BASE_IMAGE in infra/.env to pin a registry
+        # digest in prod (e.g. ghcr.io/<owner>/project-800ms-retriever-base@sha256:…).
+        BASE_IMAGE: ${RETRIEVER_BASE_IMAGE:-project-800ms-retriever-base:local}
     restart: unless-stopped
     environment:
       - DB_URL=postgresql+asyncpg://${POSTGRES_USER:-voice}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-voice}


### PR DESCRIPTION
## Summary
- Adds a new `docker-retriever` CI job that mirrors `docker-agent`'s two-stage build (base + app), caching each layer in its own GHA scope and pushing to GHCR on `main`.
- Makes the retriever's `BASE_IMAGE` env-overridable via `${RETRIEVER_BASE_IMAGE}` (parity with `AGENT_BASE_IMAGE`), so prod can pin a registry digest while local dev keeps the `:local` tag default.
- Adds a `retriever:` block to `docker-compose.prod.yml` that pulls `ghcr.io/gofrolist/project-800ms-retriever:${IMAGE_TAG:-latest}`, replacing the source build.

## Why
The retriever (added in #45) was the only service still build-from-source on the production VM. The bootstrap script does `docker compose pull && up -d`, which falls through to a build that can't resolve the local-only base image (`project-800ms-retriever-base:local`), aborts the compose run, and leaves the stack down on every fresh boot or spot preempt. This brings retriever in line with api/agent.

## Test plan
- [x] `docker compose -f infra/docker-compose.yml -f infra/docker-compose.prod.yml config` shows the merged retriever service resolves to `ghcr.io/gofrolist/project-800ms-retriever:latest` with no `build:` block.
- [x] Pre-commit `actionlint` + `Validate GitHub Workflows` + gitleaks pass.
- [ ] After merge: confirm `docker-retriever` job runs, both `project-800ms-retriever-base` and `project-800ms-retriever` packages appear in GHCR, and visibility is set to public to match the existing `project-800ms-agent` package.
- [ ] After merge: VM bootstrap on next boot pulls the published image and brings the stack up.