### PR TITLE
fix(infra): mount pg_data at /var/lib/postgresql for pg18 layout

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -81,7 +81,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       POSTGRES_DB: ${POSTGRES_DB:-voice}
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      # Postgres 18 stores data at PGDATA=/var/lib/postgresql/<major>/docker by
+      # default. Mount the parent dir so the per-major subdir lives inside the
+      # named volume. Mounting at /var/lib/postgresql/data (the pre-18 layout)
+      # makes the pg18 entrypoint refuse to start, calling our mount "unused".
+      - pg_data:/var/lib/postgresql
     ports:
       # Loopback only — postgres has a password but should never be exposed
       # to the public internet. The api/agent containers reach it via the


### PR DESCRIPTION
## Summary
Move the `pg_data` named volume from `/var/lib/postgresql/data` (pre-pg18 convention) to `/var/lib/postgresql` (pg18 convention).

## Why
On a fresh deploy, `pgvector/pgvector:pg18` refuses to start with:

> Error: in 18+, these Docker images are configured to store database data in a format which is compatible with "pg_ctlcluster" ... the suggested container configuration for 18+ is to place a single mount at `/var/lib/postgresql`

pg18 puts `PGDATA` at `/var/lib/postgresql/<major>/docker` by default. With the legacy mount at `/var/lib/postgresql/data`, the entrypoint sees the mount as "unused" (its expected data location is elsewhere) and fails closed instead of risking ignoring user data. Discovered while bringing up a fresh GCP project where the volume is empty.

## Test plan
- [x] `docker compose ... config` still resolves the postgres service.
- [ ] On the freshly-deployed VM: `docker compose up -d` brings postgres healthy, migrate runs, retriever and api come up.