### PR TITLE
feat(infra): make TTS_PRELOAD_ENGINES + qwen3 sidecar terraform-driven

### DIFF
--- a/infra/terraform-gcp/main.tf
+++ b/infra/terraform-gcp/main.tf
@@ -254,7 +254,8 @@ locals {
   startup_script = templatefile("${path.module}/startup_script.sh", {
     git_repo           = var.git_repo
     git_ref            = var.git_ref
-    image_tag          = var.image_tag
+    image_tag           = var.image_tag
+    tts_preload_engines = var.tts_preload_engines
     project_name       = var.project_name
     region             = var.region
     livekit_public_url = local.livekit_public_url

--- a/infra/terraform-gcp/startup_script.sh
+++ b/infra/terraform-gcp/startup_script.sh
@@ -27,6 +27,7 @@ TLS_EMAIL="${tls_email}"
 SECRET_PREFIX="${secret_prefix}"
 LLM_BASE_URL_TF="${llm_base_url}"
 LLM_MODEL_TF="${llm_model}"
+TTS_PRELOAD_ENGINES_TF="${tts_preload_engines}"
 
 # Compose files depend on whether TLS is enabled.
 if [ "$TLS_ENABLED" = "true" ]; then
@@ -237,6 +238,18 @@ umask 077
     printf 'DOMAIN=%s\n' "$DOMAIN"
     printf 'TLS_EMAIL=%s\n' "$TLS_EMAIL"
   fi
+  # Multi-engine TTS. The agent rejects any tts_engine not in this list
+  # with 409 — the API surfaces that as `agent_unavailable`. Default
+  # `piper` keeps the single-engine operator workflow.
+  if [ -n "$TTS_PRELOAD_ENGINES_TF" ]; then
+    printf 'TTS_PRELOAD_ENGINES=%s\n' "$TTS_PRELOAD_ENGINES_TF"
+  fi
+  # Qwen3 sidecar URL — only meaningful when the `tts-qwen3` compose
+  # profile is activated below. Writing it unconditionally is harmless:
+  # the agent only dials it when a session selects tts_engine=qwen3.
+  if printf '%s' "$TTS_PRELOAD_ENGINES_TF" | grep -qw qwen3; then
+    printf 'QWEN3_TTS_BASE_URL=http://qwen3-tts:8000/v1\n'
+  fi
 } > infra/.env
 chmod 600 infra/.env
 umask 022
@@ -259,7 +272,14 @@ umask 022
 # -----------------------------------------------------------------------------
 COMPOSE_PROFILE_FLAGS=()
 if [ -z "$LLM_BASE_URL_TF" ]; then
-  COMPOSE_PROFILE_FLAGS=(--profile local-llm)
+  COMPOSE_PROFILE_FLAGS+=(--profile local-llm)
+fi
+# Activate the qwen3-tts sidecar when the operator opted into Qwen3 via
+# `tts_preload_engines`. Without this profile the qwen3-tts service is
+# defined-but-not-running, and the agent's HTTPX call to qwen3-tts:8000
+# at session dispatch fails closed.
+if printf '%s' "$TTS_PRELOAD_ENGINES_TF" | grep -qw qwen3; then
+  COMPOSE_PROFILE_FLAGS+=(--profile tts-qwen3)
 fi
 
 docker compose --env-file infra/.env "$${COMPOSE_PROFILE_FLAGS[@]}" "$${COMPOSE_FILES[@]}" pull --ignore-pull-failures

--- a/infra/terraform-gcp/terraform.tfvars.example
+++ b/infra/terraform-gcp/terraform.tfvars.example
@@ -13,6 +13,25 @@ git_ref  = "main"
 image_tag = "latest"
 
 # -----------------------------------------------------------------------------
+# Multi-engine TTS
+#
+# Comma-separated list of engines the agent will preload at boot and accept
+# at dispatch. Sessions targeting an engine NOT in this list get 409 from the
+# agent → the API surfaces `agent_unavailable`. Default `piper` keeps the
+# single-engine operator workflow.
+#
+# Including `qwen3` automatically activates the `tts-qwen3` compose profile
+# (starts the qwen3-tts sidecar) and writes QWEN3_TTS_BASE_URL to infra/.env.
+#
+# Including `xtts` requires populated voice_library/profiles/ on disk — the
+# agent hard-fails at boot otherwise.
+#
+# Demo deployments that expose the three-button engine selector should use:
+#   tts_preload_engines = "piper,silero,qwen3"
+# -----------------------------------------------------------------------------
+tts_preload_engines = "piper"
+
+# -----------------------------------------------------------------------------
 # Spot vs on-demand
 #
 # GCP Spot VMs: ~60-70%% off on-demand. Preempted with 30s notice, boot disk

--- a/infra/terraform-gcp/variables.tf
+++ b/infra/terraform-gcp/variables.tf
@@ -173,6 +173,20 @@ variable "image_tag" {
   default     = "latest"
 }
 
+variable "tts_preload_engines" {
+  description = <<-EOT
+    Comma-separated list of TTS engines the agent should preload and accept
+    at dispatch. Valid values: piper, silero, qwen3, xtts. Including `qwen3`
+    automatically activates the `tts-qwen3` compose profile and writes
+    `QWEN3_TTS_BASE_URL=http://qwen3-tts:8000/v1` to infra/.env. Including
+    `xtts` requires populated voice_library/profiles/ on disk — the agent
+    hard-fails at boot otherwise. Default `piper` preserves the
+    single-engine operator workflow.
+  EOT
+  type        = string
+  default     = "piper"
+}
+
 variable "livekit_public_url" {
   description = "Public LiveKit URL the browser will connect to. Empty = derive from EIP."
   type        = string


### PR DESCRIPTION
## Summary
- New TF variable `tts_preload_engines` (default `piper`) plumbs the agent's preload list into `infra/.env`.
- Including `qwen3` in the list automatically appends `--profile tts-qwen3` to the compose flags so the qwen3-tts sidecar starts, and writes `QWEN3_TTS_BASE_URL=http://qwen3-tts:8000/v1`.

## Why
On a fresh deploy only `piper` worked; sessions selecting `silero` / `qwen3` / `xtts` returned `agent_unavailable` (the agent rejects any engine not in `TTS_PRELOAD_ENGINES` with 409). The compose default is `piper`, and the bootstrap script never overrode it. Bonus: even with `silero`/`qwen3` preloaded, qwen3 sessions would still fail because the `qwen3-tts` sidecar runs only under the `tts-qwen3` compose profile, which wasn't being activated.

## What this fixes
- `tts_preload_engines = "piper,silero,qwen3"` in tfvars → all three engines are healthy after `terraform apply` + VM rebuild (or the next spot preempt re-running bootstrap).
- `xtts` is intentionally not in the recommended set — its preload hard-fails when `voice_library/profiles/` is empty, which it is by default in the repo.

## Test plan
- [x] `terraform validate` passes.
- [x] Pre-commit (gitleaks, file hygiene) passes.
- [ ] After merge: bump `tts_preload_engines = "piper,silero,qwen3"` in local tfvars, `terraform apply` to refresh instance metadata, force a VM stop/start (or wait for next spot preempt), then verify `GET /v1/engines` reports all three `available: true`.