### PR TITLE
fix(infra): in-place startup script metadata + pin boot image

### DIFF
--- a/infra/terraform-gcp/main.tf
+++ b/infra/terraform-gcp/main.tf
@@ -336,9 +336,17 @@ resource "google_compute_instance" "main" {
     enable-oslogin = "TRUE"
     # Block legacy V1 metadata access — only V2 (header-based) is allowed.
     block-project-ssh-keys = "TRUE"
+    # The script body lives in the regular metadata map (in-place updatable)
+    # rather than the dedicated metadata_startup_script field (ForceNew on
+    # change). This means a `terraform apply` that only edits the bootstrap
+    # logic patches the running VM's metadata instead of destroying and
+    # recreating the instance — critical for spot deploys, where a stockout
+    # at recreate time leaves the service down with no rollback path.
+    # The instance picks up the new script on next boot (manual stop/start
+    # or spot preempt). To force an immediate refresh:
+    #   gcloud compute instances reset <name> --zone <zone> --project <p>
+    startup-script = local.startup_script
   }
-
-  metadata_startup_script = local.startup_script
 
   depends_on = [
     google_project_iam_member.logs_writer,
@@ -346,6 +354,21 @@ resource "google_compute_instance" "main" {
     google_secret_manager_secret_iam_member.instance_accessor,
     google_secret_manager_secret_version.app,
   ]
+
+  lifecycle {
+    # The Deep Learning VM image family rolls forward continuously
+    # (v20260427 → v20260430 → …). Without this, every `terraform apply`
+    # picks up the latest tag and forces VM replacement — which is
+    # exactly the spot-stockout-at-recreate failure mode that just bit
+    # us in production. Pinning the image attribute means routine
+    # applies (variable edits, metadata patches) leave the boot disk
+    # alone. To deliberately roll the image, taint and recreate:
+    #   terraform taint google_compute_instance.main
+    #   terraform apply
+    ignore_changes = [
+      boot_disk[0].initialize_params[0].image,
+    ]
+  }
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
Two lifecycle fixes on `google_compute_instance.main` so routine `terraform apply` runs no longer trigger VM replacement:

1. **Move the bootstrap script from `metadata_startup_script` (ForceNew) to `metadata.startup-script` (in-place updatable).** Edits to the script body now patch the running VM's metadata; the next boot picks them up. Operators force an immediate refresh via `gcloud compute instances reset <name> --zone <zone> --project <p>`.
2. **`lifecycle.ignore_changes` on the boot disk image.** The Deep Learning VM image family rolls forward continuously (`v20260427 → v20260430 → …`). Without this, every apply silently retags the boot image → ForceNew replacement.

## Why
A `terraform apply` carrying a TF-variable change for `tts_preload_engines` just destroyed the production VM and a spot stockout at recreate time left the service down for ~10 minutes. Both fixes target the underlying class of problem: an L4 spot deploy needs apply-time idempotency for everything except deliberate hardware-shape changes.

## Verification
`terraform plan` before this PR (with no other variable edits) showed `1 to add, 1 to destroy` because the boot image had drifted upstream. After this PR:

```
Plan: 0 to add, 1 to change, 0 to destroy
```

The single in-place change is the metadata `startup-script` key being added to the running instance.

## Rollout
- [x] `terraform validate` passes.
- [ ] After merge: locally pull, `terraform apply` to apply the metadata patch in place. The VM keeps running. The next boot/preempt picks up the new bootstrap.
- [ ] Document operator runbook: to deliberately roll the boot image, `terraform taint google_compute_instance.main` then apply.