### PR TITLE
fix(retriever): /ready probe — switch to GET /models, two-tier TTL cache

### DIFF
--- a/services/retriever/health.py
+++ b/services/retriever/health.py
@@ -6,7 +6,8 @@
 `/ready`   — the service is actually able to serve `/retrieve`. Verifies:
    (a) embedder singleton is loaded,
    (b) DB pool can execute `SELECT 1`,
-   (c) rewriter LLM answered a hello-ping within the last 30 s (cached).
+   (c) the rewriter LLM endpoint is reachable (cached probe — see
+       `_check_rewriter_cached`).
    Used by the docker-compose healthcheck (start_period: 600s — matches
    HF_HUB_DOWNLOAD_TIMEOUT so a slow cold download can't trigger a
    kill/re-download boot loop).
@@ -34,7 +35,24 @@ from embedder import is_loaded as embedder_is_loaded
 
 router = APIRouter(tags=["health"])
 
-_REWRITER_CACHE_TTL_SECONDS = 30.0
+# Two-tier cache for the rewriter probe. Successful probes are trusted for 5
+# minutes; failed probes for 1 minute. The asymmetry is deliberate:
+#
+# * 300 s on success keeps the docker healthcheck (10 s interval) below the
+#   provider's per-day request budget on free tiers — Groq's 1000 RPD on
+#   `/chat/completions` is the bound that bit us when this was 30 s and
+#   billable; switching to the unbilled `/models` GET (see
+#   `_check_rewriter_cached`) plus the 5-min cache puts us at 288/day.
+# * 60 s on failure prevents a single transient hiccup (network blip, brief
+#   per-minute rate-limit window, upstream 5xx) from poisoning the cache for
+#   the full 5-minute window. A revoked key still surfaces within one minute.
+_REWRITER_CACHE_TTL_OK = 300.0
+_REWRITER_CACHE_TTL_FAIL = 60.0
+# HTTP statuses that indicate the rewriter is NOT ready and the cached
+# negative result should page operators on the next /ready call. Auth
+# failures (401/403), wrong base URL (404), and quota exhaustion (429) are
+# operator-visible problems, not transient network issues.
+_REWRITER_NOT_READY_STATUSES = frozenset({401, 403, 404, 429})
 # The probe itself has a budget well inside the compose healthcheck
 # timeout (3 s). Keeping it at 2.5 s leaves 500 ms headroom.
 _REWRITER_PROBE_TIMEOUT = httpx.Timeout(2.5, connect=1.0)
@@ -48,14 +66,28 @@ class _RewriterCache:
 
 _rewriter_cache = _RewriterCache()
 # Serialises the in-flight probe so N concurrent /ready calls produce
-# one LLM POST, not N. Defeats the cold-start thundering-herd.
+# one LLM request, not N. Defeats the cold-start thundering-herd.
 _rewriter_lock = asyncio.Lock()
 
 
 def reset_rewriter_cache() -> None:
-    """Test seam — clear the cached rewriter-probe result."""
+    """Test seam — clear the cached rewriter-probe result and reset the lock.
+
+    The lock reset is defensive: a test that cancels a coroutine mid-probe
+    would otherwise leave `_rewriter_lock` permanently held in module state,
+    deadlocking every subsequent test that touches `_check_rewriter_cached`.
+    """
+    global _rewriter_lock
     _rewriter_cache.ok = False
     _rewriter_cache.ts = float("-inf")
+    _rewriter_lock = asyncio.Lock()
+
+
+def _is_cache_fresh(now: float) -> bool:
+    """Two-tier cache freshness. Reads `_rewriter_cache.ok` (no lock; safe
+    in single-threaded asyncio) and picks the matching TTL."""
+    ttl = _REWRITER_CACHE_TTL_OK if _rewriter_cache.ok else _REWRITER_CACHE_TTL_FAIL
+    return now - _rewriter_cache.ts < ttl
 
 
 @router.get("/healthz", include_in_schema=True)
@@ -92,39 +124,35 @@ async def ready(response: Response) -> dict[str, object]:
 
 
 async def _check_rewriter_cached() -> bool:
-    """Probe the rewriter LLM with a trivial call, cached for 30 s.
+    """Probe the rewriter LLM endpoint with a metadata GET, cached.
 
-    Serialised by `_rewriter_lock` so only one probe runs at a time — the
-    classic cold-start thundering-herd where N concurrent /ready calls
-    would otherwise fan out N real LLM POSTs.
+    Hits ``GET {llm_base_url}/models`` — part of the OpenAI-compatible
+    surface that Groq, vLLM, and OpenAI all implement, and (unlike
+    ``POST /chat/completions``) unbilled on every provider we target.
+    Cache TTLs are asymmetric (see module-level constants).
+
+    Serialised by `_rewriter_lock` so concurrent /ready calls produce
+    one in-flight request, not N.
     """
     now = time.monotonic()
-    if now - _rewriter_cache.ts < _REWRITER_CACHE_TTL_SECONDS:
+    if _is_cache_fresh(now):
         return _rewriter_cache.ok
 
     async with _rewriter_lock:
         # Another probe may have refreshed the cache while we were
         # waiting for the lock.
         now = time.monotonic()
-        if now - _rewriter_cache.ts < _REWRITER_CACHE_TTL_SECONDS:
+        if _is_cache_fresh(now):
             return _rewriter_cache.ok
 
         settings = get_settings()
-        url = f"{str(settings.llm_base_url).rstrip('/')}/chat/completions"
+        url = f"{str(settings.llm_base_url).rstrip('/')}/models"
         headers = {"Authorization": f"Bearer {settings.llm_api_key}"}
-        payload = {
-            "model": settings.rewriter_model,
-            "messages": [{"role": "user", "content": "ping"}],
-            "max_tokens": 1,
-            "temperature": 0.0,
-        }
         try:
             async with httpx.AsyncClient(timeout=_REWRITER_PROBE_TIMEOUT) as client:
-                resp = await client.post(url, headers=headers, json=payload)
-            # Treat auth / not-found / rate-limit as NOT ready — a revoked
-            # key should page, not silently green-light the probe.
+                resp = await client.get(url, headers=headers)
             status = resp.status_code
-            ok = 200 <= status < 500 and status not in (401, 403, 404, 429)
+            ok = 200 <= status < 500 and status not in _REWRITER_NOT_READY_STATUSES
             if not ok:
                 logger.warning("ready.rewriter_non_ok status={status}", status=status)
         except Exception as exc:  # noqa: BLE001

--- a/services/retriever/tests/test_health.py
+++ b/services/retriever/tests/test_health.py
@@ -1,0 +1,268 @@
+"""Unit tests for the readiness-probe LLM check.
+
+Targets `_check_rewriter_cached()` in `services/retriever/health.py`.
+The probe is a metadata GET against `{llm_base_url}/models`, NOT a chat
+completion — calling it on a 30 s cadence against a free-tier provider
+(Groq's 1000 RPD) used to burn ~2880 calls/day and silently 503 every
+/retrieve call once the daily cap hit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+
+import httpx
+import pytest
+import respx
+
+from health import (
+    _REWRITER_CACHE_TTL_FAIL,
+    _REWRITER_CACHE_TTL_OK,
+    _check_rewriter_cached,
+    reset_rewriter_cache,
+)
+
+_LLM_BASE = "http://llm-test.local"
+_MODELS_URL = f"{_LLM_BASE}/models"
+_CHAT_URL = f"{_LLM_BASE}/chat/completions"
+
+
+@pytest.fixture(autouse=True)
+def _llm_env(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """Point the probe at a mock LLM host per-test, and clear the
+    rewriter cache so each test starts from a known state."""
+    monkeypatch.setenv("DB_URL", "postgresql+asyncpg://placeholder/placeholder")
+    monkeypatch.setenv("LLM_BASE_URL", _LLM_BASE)
+    monkeypatch.setenv("LLM_API_KEY", "test-api-key")
+    monkeypatch.setenv("REWRITER_MODEL", "default-model")
+    from config import get_settings
+
+    get_settings.cache_clear()
+    reset_rewriter_cache()
+    yield
+    get_settings.cache_clear()
+    reset_rewriter_cache()
+
+
+@pytest.mark.asyncio
+async def test_probe_uses_models_endpoint_not_chat_completions() -> None:
+    """The whole point of the fix: don't hit the billed chat surface.
+
+    Asserts the probe issues GET /models with the bearer token and
+    consumes zero quota at /chat/completions.
+    """
+    with respx.mock(assert_all_called=False) as mock:
+        models_route = mock.get(_MODELS_URL).respond(200, json={"data": [{"id": "default-model"}]})
+        chat_route = mock.post(_CHAT_URL).respond(200, json={})
+
+        ok = await _check_rewriter_cached()
+
+        assert ok is True
+        assert models_route.called
+        assert models_route.calls.last.request.headers["authorization"] == "Bearer test-api-key"
+        assert chat_route.call_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [401, 403, 404, 429])
+async def test_auth_and_quota_errors_report_not_ready(status: int) -> None:
+    """A revoked key (401/403), a wrong base URL (404), or a rate-limit
+    (429) must surface as `not ready` so operators get paged."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(_MODELS_URL).respond(status)
+
+        ok = await _check_rewriter_cached()
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_5xx_reports_not_ready() -> None:
+    """Upstream LLM hard-failure → not ready. The retriever should let
+    the orchestrator restart the container rather than silently degrade."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(_MODELS_URL).respond(500)
+
+        ok = await _check_rewriter_cached()
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_2xx_reports_ready() -> None:
+    """Anything in [200, 500) that isn't an auth/quota signal counts as ready."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(_MODELS_URL).respond(204)
+
+        ok = await _check_rewriter_cached()
+
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_network_error_reports_not_ready() -> None:
+    """A connect/timeout failure surfaces as not-ready without leaking
+    asyncpg/httpx exception messages (which can carry credentials)."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(_MODELS_URL).mock(side_effect=httpx.ConnectError("kaboom"))
+
+        ok = await _check_rewriter_cached()
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_result_is_cached_within_ttl() -> None:
+    """Two probes inside the OK-TTL window must produce one HTTP call.
+
+    This is the headline cost fix — the docker healthcheck fires every
+    10 s; without caching, that's a request every 10 s = 8640/day."""
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.get(_MODELS_URL).respond(200, json={"data": []})
+
+        first = await _check_rewriter_cached()
+        second = await _check_rewriter_cached()
+
+        assert first is True
+        assert second is True
+        assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_negative_result_is_cached_within_fail_ttl() -> None:
+    """A failed probe must also be cached — within the fail TTL — so the
+    healthcheck firing every 10 s doesn't spam the LLM with retries during
+    a sustained outage. Pinned separately from the OK case because the
+    fail-TTL was the regression vector before two-tier caching."""
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.get(_MODELS_URL).respond(401)
+
+        first = await _check_rewriter_cached()
+        second = await _check_rewriter_cached()
+
+        assert first is False
+        assert second is False
+        assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_probes_collapse_to_one_request() -> None:
+    """Cold-start thundering-herd: N concurrent /ready calls before the
+    cache is warm must coalesce into a single LLM request via the lock.
+
+    Uses an asyncio.Event to gate the first probe in-flight: the side_effect
+    awaits the event before responding, ensuring all 8 coroutines pass the
+    pre-lock cache check (cold) and queue at the lock. Without the
+    `_rewriter_lock`, this configuration would issue 8 real requests; the
+    `call_count == 1` assertion is therefore load-bearing for the lock.
+    """
+    release = asyncio.Event()
+
+    async def gated_response(request: httpx.Request) -> httpx.Response:
+        await release.wait()
+        return httpx.Response(200, json={"data": []})
+
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.get(_MODELS_URL).mock(side_effect=gated_response)
+
+        async def kick_off() -> bool:
+            return await _check_rewriter_cached()
+
+        tasks = [asyncio.create_task(kick_off()) for _ in range(8)]
+        # Yield control so every task reaches the lock-acquire await before
+        # the first one is allowed to complete its HTTP call.
+        for _ in range(8):
+            await asyncio.sleep(0)
+        release.set()
+
+        results = await asyncio.gather(*tasks)
+
+        assert all(results)
+        assert route.call_count == 1
+
+
+def test_cache_ttls_are_set_to_safe_defaults() -> None:
+    """Pin the two-tier TTL values so a future change can't silently
+    re-introduce the quota-burn issue (OK TTL too low) or the
+    transient-failure-poisoning issue (FAIL TTL too high) without a
+    failing test forcing a deliberate revisit. Plain sync assertions —
+    no event loop required."""
+    assert _REWRITER_CACHE_TTL_OK == 300.0
+    assert _REWRITER_CACHE_TTL_FAIL == 60.0
+
+
+@pytest.mark.asyncio
+async def test_cache_expires_after_ok_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Past the OK-TTL window, the next probe re-hits the LLM.
+
+    Patches `time.monotonic` rather than sleeping — the test must stay
+    fast and not depend on real wall-clock time."""
+    fake_now = [0.0]
+
+    def fake_monotonic() -> float:
+        return fake_now[0]
+
+    monkeypatch.setattr("health.time.monotonic", fake_monotonic)
+
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.get(_MODELS_URL).respond(200, json={"data": []})
+
+        fake_now[0] = 0.0
+        await _check_rewriter_cached()
+        fake_now[0] = _REWRITER_CACHE_TTL_OK - 1.0
+        await _check_rewriter_cached()  # still cached
+        fake_now[0] = _REWRITER_CACHE_TTL_OK + 1.0
+        await _check_rewriter_cached()  # cache expired → re-probe
+
+        assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_expires_after_fail_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed probe re-fires after the (shorter) fail TTL — the whole
+    point of the two-tier design. A 60 s outage of the LLM should not
+    manifest as 5 minutes of degraded readiness."""
+    fake_now = [0.0]
+
+    def fake_monotonic() -> float:
+        return fake_now[0]
+
+    monkeypatch.setattr("health.time.monotonic", fake_monotonic)
+
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.get(_MODELS_URL).respond(429)
+
+        fake_now[0] = 0.0
+        await _check_rewriter_cached()
+        fake_now[0] = _REWRITER_CACHE_TTL_FAIL - 1.0
+        await _check_rewriter_cached()  # still cached as failure
+        fake_now[0] = _REWRITER_CACHE_TTL_FAIL + 1.0
+        await _check_rewriter_cached()  # fail TTL expired → re-probe
+
+        assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_failure_does_not_extend_to_ok_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression guard: if the cache used a single TTL again, a failed
+    probe would stay cached for 5 min and this test would catch it.
+    Probing at fail_ttl+1 must re-fire even though we're still well
+    under ok_ttl."""
+    fake_now = [0.0]
+
+    def fake_monotonic() -> float:
+        return fake_now[0]
+
+    monkeypatch.setattr("health.time.monotonic", fake_monotonic)
+
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.get(_MODELS_URL).respond(500)
+
+        fake_now[0] = 0.0
+        await _check_rewriter_cached()
+        # Halfway between fail TTL and ok TTL — must NOT be a cache hit.
+        fake_now[0] = (_REWRITER_CACHE_TTL_FAIL + _REWRITER_CACHE_TTL_OK) / 2.0
+        await _check_rewriter_cached()
+
+        assert route.call_count == 2


### PR DESCRIPTION
## Summary
- Switch the `/ready` rewriter probe from `POST /chat/completions` (billed) to `GET /models` (unbilled) on the same OpenAI-compatible endpoint. Same auth/quota/reachability signals (401/403/404/429), zero RPD impact on Groq, OpenAI, or vLLM.
- Two-tier cache TTL: **300s on success**, **60s on failure**. Asymmetric by design — see Why.

## Why
`/ready` was firing a billable chat-completion every ~30s (the docker healthcheck interval × the prior single-tier 30s cache TTL = roughly 2880 calls/day) and exhausting Groq's 1000-RPD free-tier daily quota. Once the cap hit, `/retrieve`'s rewriter call shared the same key/model and also returned 503, surfacing as `agent_unavailable` to the SPA for every TTS engine except piper (whose static greetings don't need the LLM).

A single-TTL fix (just switching to `/models`, keeping 30s or even bumping to 300s) would still cache transient failures for the full window. With `_REWRITER_CACHE_TTL_FAIL = 60s`, a network blip or per-minute rate-limit window self-heals in ~1 min instead of poisoning readiness for 5 min.

## Verification
- 15/15 unit tests pass (was 12, +3 for two-tier behavior). All `respx`-based; the concurrent-probe test now uses an `asyncio.Event` gate so the lock is genuinely load-bearing for the `call_count == 1` assertion.
- `ruff check` clean, `ruff format` clean.
- Math: 86400/300 = 288 calls/day on success ≪ 1000 RPD. Confirmed live: pre-fix Groq dashboard showed 9h of sustained 429s with the exact 36-input/1-output token fingerprint of the old `{"messages": [{"role": "user", "content": "ping"}], "max_tokens": 1}` payload.

## Test plan
- [x] `uv run pytest tests/test_health.py -v` → 15/15 passed.
- [x] `ruff check . && ruff format --check .` clean.
- [ ] After merge: deploy to the VM, confirm Groq dashboard shows ≤1 GET /models per 5 min on the `gcp-demo` key, no `/chat/completions` traffic from this service.
- [ ] Follow-up PR: add a FastAPI `TestClient` test for `GET /ready` itself (the current tests target the internal `_check_rewriter_cached` helper; the route-level branches — embedder check, db check, 503-status response — are still untested in this diff).

## Review-driven changes
This PR was synthesized from a `/code-review` run that surfaced 18 findings; 8 were applied here, 1 deferred (FastAPI route test, see Test plan), and 8 skipped with rationale recorded in `.context/compound-engineering/ce-code-review/20260430-120646-70629e0b/synthesis.json`.