### PR TITLE
feat(infra): bootstrap RETRIEVER_INTERNAL_TOKEN + RETRIEVER_URL on every boot

### DIFF
--- a/infra/terraform-gcp/main.tf
+++ b/infra/terraform-gcp/main.tf
@@ -201,8 +201,9 @@ locals {
     # Optional API seed key. Sentinel + startup script treat __UNSET__ as
     # empty so downstream compose falls back to defaults.
     seed_demo_api_key    = var.seed_demo_api_key == "" ? "__UNSET__" : var.seed_demo_api_key
-    agent_internal_token = var.agent_internal_token == "" ? "__UNSET__" : var.agent_internal_token
-    admin_api_key        = var.admin_api_key == "" ? "__UNSET__" : var.admin_api_key
+    agent_internal_token     = var.agent_internal_token == "" ? "__UNSET__" : var.agent_internal_token
+    retriever_internal_token = var.retriever_internal_token == "" ? "__UNSET__" : var.retriever_internal_token
+    admin_api_key            = var.admin_api_key == "" ? "__UNSET__" : var.admin_api_key
   }
 }
 

--- a/infra/terraform-gcp/startup_script.sh
+++ b/infra/terraform-gcp/startup_script.sh
@@ -163,6 +163,24 @@ if [ "$AGENT_INTERNAL_TOKEN" = "__UNSET__" ]; then
   AGENT_INTERNAL_TOKEN=$(cat "$TOKEN_FILE")
 fi
 
+# Agent <-> retriever internal token. Same auto-generate-and-persist
+# pattern as the AGENT_INTERNAL_TOKEN above — both agent and retriever
+# read the value from infra/.env, so as long as bootstrap writes the
+# same value to both, the token always matches. Without this, the
+# compose `:?` validation rejects the deploy on first boot of any VM
+# whose tfvars doesn't carry an explicit token value.
+RETRIEVER_INTERNAL_TOKEN=$(secret_get retriever_internal_token)
+if [ "$RETRIEVER_INTERNAL_TOKEN" = "__UNSET__" ]; then
+  TOKEN_FILE=/etc/project-800ms/retriever-token
+  mkdir -p /etc/project-800ms
+  chmod 700 /etc/project-800ms
+  if [ ! -s "$TOKEN_FILE" ]; then
+    openssl rand -hex 32 > "$TOKEN_FILE"
+    chmod 600 "$TOKEN_FILE"
+  fi
+  RETRIEVER_INTERNAL_TOKEN=$(cat "$TOKEN_FILE")
+fi
+
 ADMIN_API_KEY=$(secret_get admin_api_key)
 if [ "$ADMIN_API_KEY" = "__UNSET__" ]; then
   ADMIN_API_KEY=""
@@ -221,6 +239,13 @@ umask 077
   printf 'SEED_DEMO_API_KEY=%s\n' "$SEED_DEMO_API_KEY"
   # Shared agent <-> api secret for transcript persistence.
   printf 'AGENT_INTERNAL_TOKEN=%s\n' "$AGENT_INTERNAL_TOKEN"
+  # Helper/Guide NPC RAG bridge. RETRIEVER_INTERNAL_TOKEN is enforced
+  # on both sides via compose `:?` — without it, agent + retriever
+  # both fail to start. RETRIEVER_URL points the agent at the local
+  # retriever sidecar; empty would drop the agent into KB-passthrough
+  # mode and silently disable the RAG path.
+  printf 'RETRIEVER_INTERNAL_TOKEN=%s\n' "$RETRIEVER_INTERNAL_TOKEN"
+  printf 'RETRIEVER_URL=http://retriever:8002\n'
   # Master admin key — empty disables the /v1/admin/* surface.
   printf 'ADMIN_API_KEY=%s\n' "$ADMIN_API_KEY"
   # The demo SPA embeds this key. Default to the seeded 'demo' tenant

--- a/infra/terraform-gcp/terraform.tfvars.example
+++ b/infra/terraform-gcp/terraform.tfvars.example
@@ -112,6 +112,20 @@ llm_api_key  = ""
 seed_demo_api_key = ""  # e.g. "tk_0123...abcd"
 
 # -----------------------------------------------------------------------------
+# Retriever <-> agent shared secret
+#
+# The agent presents this to the retriever's /retrieve endpoint as
+# `X-Internal-Token`; the retriever validates against its own copy.
+# Compose enforces non-empty on both sides — without this, agent +
+# retriever fail to start. Empty here triggers the same auto-generate-
+# and-persist fallback used for agent_internal_token (file lives at
+# /etc/project-800ms/retriever-token, survives spot preemptions). Set
+# to a deliberate value only when rotating per
+# docs/solutions/security-issues/retriever-internal-token-rotation-2026-04-27.md.
+# -----------------------------------------------------------------------------
+retriever_internal_token = ""  # auto-generated when empty
+
+# -----------------------------------------------------------------------------
 # Access
 # -----------------------------------------------------------------------------
 allowed_app_cidr = "0.0.0.0/0"

--- a/infra/terraform-gcp/variables.tf
+++ b/infra/terraform-gcp/variables.tf
@@ -319,6 +319,23 @@ variable "agent_internal_token" {
   default     = ""
 }
 
+variable "retriever_internal_token" {
+  description = <<-EOT
+    Shared secret the agent presents to the retriever's `/retrieve`
+    endpoint as `X-Internal-Token`, and the retriever validates against
+    its own copy. Both agent and retriever are wired to fail closed
+    when the token is missing -- empty here triggers the same auto-
+    generate-and-persist fallback used for `agent_internal_token`,
+    keeping the value stable across spot preemptions via
+    `/etc/project-800ms/retriever-token`. Set to a deliberate value
+    only when rotating per the playbook in
+    `docs/solutions/security-issues/retriever-internal-token-rotation-2026-04-27.md`.
+  EOT
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # -----------------------------------------------------------------------------
 # Admin API key (optional)
 #


### PR DESCRIPTION
## Summary
Adds a new TF variable `retriever_internal_token` (sensitive, default empty) plumbed through Secret Manager and the bootstrap script. Mirrors the existing `agent_internal_token` pattern exactly: empty → `__UNSET__` sentinel → auto-generate-and-persist at `/etc/project-800ms/retriever-token` so the value survives spot preemptions. Bootstrap also unconditionally emits `RETRIEVER_URL=http://retriever:8002` to `infra/.env`.

## Why
PR #52 (Helper/Guide NPC US2) made compose enforce `RETRIEVER_INTERNAL_TOKEN` on both agent and retriever via `:?` substitution. After that landed, the live VM only stayed up because I hot-patched both vars into `infra/.env` by hand. The next spot preempt would have regenerated `.env` from terraform inputs (which didn't carry these) and left agent + retriever both refusing to start with `RETRIEVER_INTERNAL_TOKEN is required`.

Same class of bug as the pre-PR-#60 state: a new compose env requirement landed without the corresponding bootstrap plumbing, leaving the deploy fragile against the next reboot.

## Changes
- `variables.tf`: new `retriever_internal_token` variable.
- `main.tf`: add to `local.app_secrets` so a Secret Manager secret + version + IAM binding get created.
- `startup_script.sh`: fetch the secret with `secret_get`, fall back to a hex token persisted in `/etc/project-800ms/retriever-token`, and emit `RETRIEVER_INTERNAL_TOKEN=…` + `RETRIEVER_URL=http://retriever:8002` to `infra/.env`.
- `terraform.tfvars.example`: document the new variable + auto-generate behavior.

## Test plan
- [x] `terraform validate` clean.
- [x] `terraform plan` against the live VM: `3 to add, 1 to change, 0 to destroy` — the 3 adds are the new Secret Manager resources, the 1 change is the in-place metadata-startup-script patch (no instance replacement, courtesy of PR #61).
- [ ] After merge: `terraform apply` to roll forward. The live containers keep running with the hot-patched values; on next preempt or `gcloud compute instances reset`, bootstrap reads the new secret (or auto-generates if tfvars is empty) and writes both vars to `infra/.env`. Compose comes up clean.