### PR TITLE
KB ingestion pipeline — chunker, ingest CLI, synth questions, scheduled refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# KB fetch output (tools/fetch_chatwoot_kb.py and similar). Treated as a
+# runtime artifact — the source of truth lives upstream (Chatwoot, etc.).
+# Test fixtures live under services/*/tests/fixtures/ instead.
+data/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/docs/solutions/best-practices/kb-ingestion-pipeline-2026-04-30.md
+++ b/docs/solutions/best-practices/kb-ingestion-pipeline-2026-04-30.md
@@ -1,0 +1,240 @@
+---
+title: "KB ingestion pipeline — fetch, ingest, and scheduled refresh"
+module: services/retriever
+date: 2026-04-30
+category: docs/solutions/best-practices
+problem_type: operational_runbook
+component: kb_ingestion
+severity: low
+root_cause: external_kb_drift_requires_periodic_resync
+resolution_type: runbook
+symptoms:
+  - Helper/Guide NPC answers go stale after upstream Chatwoot articles change
+  - First-time tenant onboarding needs an initial KB seed before any retrieval works
+  - Operator wants to add a new article and have it answerable within the hour
+tags:
+  - kb-ingestion
+  - chatwoot
+  - chunker
+  - synthetic-questions
+  - mass-deletion-safeguard
+  - cron
+---
+
+# What this is
+
+The end-to-end pipeline for getting Russian KB content from an external
+source (today: Chatwoot help-base) into the retriever's
+`kb_entries` / `kb_chunks` tables, plus the operator-facing wrapper
+that wires it as a scheduled refresh.
+
+Two scripts, one inside-container CLI, one cron entry.
+
+```
+[cron @ 04:00]
+   ↓
+scripts/refresh_kb.sh demo arizona
+   ├─ tools/fetch_chatwoot_kb.py  → data/kb/arizona/<id>.json + _manifest.json  (host)
+   └─ docker compose exec retriever uv run python -m ingest
+        --tenant demo --source /app/data/kb/arizona/ --mode incremental
+        ├─ chunk via chunker (markdown-aware, BGE-M3-bounded sizes)
+        ├─ embed each chunk (BGE-M3, 1024-dim)
+        ├─ upsert kb_entries + replace kb_chunks atomically
+        └─ synthetic-question phase (rewriter LLM → N=4 paraphrases per chunk)
+```
+
+# When to use
+
+- **First deploy** of a tenant — initial KB seed.
+- **Daily scheduled refresh** — pick up new / edited / deleted Chatwoot
+  articles. Idempotent, so daily is cheap.
+- **After a Chatwoot bulk edit** — operator can run on demand without
+  waiting for cron.
+- **After bumping `REWRITER_VERSION`** in synthetic_questions — re-run
+  with `--mode full` to regenerate every embedding, then a normal run
+  to fill in synth questions.
+
+# How it works
+
+## Fetch (host side, Python stdlib only)
+
+`tools/fetch_chatwoot_kb.py`:
+
+- Reads `CHATWOOT_HELP_BASE_TOKEN` from env.
+- GETs `https://chatwoot.arizona-rp.com/api-help-base/get?project=<p>`.
+- Writes one JSON file per article under `data/kb/<project>/<id>.json`
+  in the canonical shape:
+
+  ```json
+  {
+    "kb_entry_key": "chatwoot:<id>",
+    "title": "...",
+    "content": "...markdown...",
+    "source_uri": "...",
+    "metadata": {"category_name": "...", "portal_name": "...", "source": "chatwoot"}
+  }
+  ```
+
+- Writes `_manifest.json` listing all fetched IDs (forensic record + a
+  "fetch ran successfully" sentinel for `refresh_kb.sh`).
+
+The fetch is **non-destructive on disk** — files for articles that
+disappear upstream are NOT removed by the fetcher. The ingest step's
+diff handles deletions via DB cascade. This separation means a partial
+fetch never destroys local source-of-truth.
+
+## Ingest (inside the retriever container)
+
+`services/retriever/ingest.py`:
+
+1. Resolves tenant slug → tenant_id, acquires per-tenant
+   `pg_advisory_xact_lock`. Two concurrent ingests for the same tenant
+   block; different tenants run in parallel.
+2. Loads source JSONs, validates the canonical shape, computes
+   per-entry `content_sha256` over normalised content.
+3. Loads existing `kb_entries WHERE kb_entry_key LIKE '<namespace>:%'`
+   (scoped to the source's namespace so a `chatwoot` ingest never
+   touches a `wiki:*` entry from a different fetcher).
+4. Diff → `add` / `update` / `unchanged` / `delete` sets.
+5. **Mass-deletion safeguard** — refuses to delete >25% of existing
+   entries (above floor of 4) unless `--allow-mass-deletion` is
+   passed. Catches "Chatwoot returned 0 articles because the API key
+   was rotated" before it nukes the KB.
+6. For each add/update: chunk via `chunker.chunk_article` (heading-
+   aware, MAX_CHARS=1500 with overlap), embed each chunk via BGE-M3,
+   atomically replace `kb_chunks` rows.
+7. For each delete: `DELETE FROM kb_entries WHERE kb_entry_key = ?` —
+   cascades to chunks via FK.
+8. Synthetic-question phase (`synthetic_questions.run`) — finds content
+   chunks with no synthetic-question children, generates N=4
+   paraphrased Russian questions per chunk via the rewriter LLM,
+   embeds and inserts as `is_synthetic_question=TRUE` rows.
+
+## Synthetic questions — why a separate phase
+
+Generation is the slow + expensive step (~1 LLM call per chunk; ~200
+calls for the Chatwoot feed; ~30s wall time on Groq llama-3.3-70b).
+Splitting it from the content commit means:
+
+- **Content phase commits first.** A rate-limited / down LLM blocks
+  generation but never blocks new content from being retrievable.
+- **Resumable on retry.** The phase queries `kb_chunks WHERE NOT EXISTS
+  (SELECT 1 FROM kb_chunks sq WHERE sq.parent_chunk_id = c.id)` — so
+  next run picks up exactly the chunks the previous run missed.
+- **Auto-regenerates on content change.** When the content phase
+  replaces a chunk's row, its synthetic children cascade-delete via
+  the parent_chunk_id FK; the chunk becomes "naked" again and the
+  next synth pass regenerates.
+- **Bounded retry.** Up to 3 attempts per call with exponential
+  backoff (0.5s, 1s, 2s). 5 consecutive total failures abort the
+  phase — the LLM is genuinely down or quota is exhausted, no value
+  in burning more attempts.
+
+## Scheduled refresh on the VM
+
+`scripts/refresh_kb.sh`:
+
+```bash
+sudo crontab -e
+0 4 * * * /opt/project-800ms/scripts/refresh_kb.sh demo arizona >> \
+    /var/log/project-800ms-kb-refresh.log 2>&1
+```
+
+The script:
+
+1. Sources `infra/.env` to inherit `CHATWOOT_HELP_BASE_TOKEN`.
+2. Runs the fetch step on the host. Exits with code 2 on fetch
+   failure (DB unchanged, retry tomorrow).
+3. Sanity-checks `_manifest.json` — exits 2 if upstream returned 0
+   articles (clear log message rather than triggering the deletion
+   safeguard inside ingest).
+4. Runs `docker compose exec retriever uv run python -m ingest ...`
+   so the heavy BGE-M3 embedder (already loaded in the long-lived
+   retriever process) is reused, saving ~6s of cold-load cost.
+5. Reports per-phase JSON lines + diagnostic loguru output to
+   stdout/stderr for log aggregation.
+
+# Operator commands
+
+## First-time seed
+
+```bash
+# Make sure the chatwoot_help_base_token is set in terraform.tfvars
+# and applied. Then on the VM:
+ssh <vm> "cd /opt/project-800ms && ./scripts/refresh_kb.sh demo arizona"
+```
+
+## Test in dry-run mode (locally or on VM)
+
+```bash
+docker compose exec retriever uv run python -m ingest \
+    --tenant demo --source /app/data/kb/arizona/ \
+    --mode incremental --dry-run
+```
+
+Returns the diff plan without writing — the fastest way to confirm
+"does upstream look reasonable" before running for real.
+
+## Force-regenerate every chunk
+
+```bash
+docker compose exec retriever uv run python -m ingest \
+    --tenant demo --source /app/data/kb/arizona/ \
+    --mode full
+```
+
+Use after bumping the embedder model or REWRITER_VERSION. Runs through
+every article as if its content_sha256 had changed.
+
+## Override the mass-deletion safeguard
+
+```bash
+docker compose exec retriever uv run python -m ingest \
+    --tenant demo --source /app/data/kb/arizona/ \
+    --allow-mass-deletion
+```
+
+Use only when a deliberate cleanup is in progress (e.g. operator pruned
+50 stale articles upstream and wants the deletion to flow through). For
+the steady-state daily refresh, leave it off — the safeguard is the
+last line of defense between "Chatwoot auth flipped" and "demo tenant
+has no KB anymore".
+
+## Inspect the result
+
+```sql
+-- entries per namespace
+SELECT split_part(kb_entry_key, ':', 1) AS source, count(*)
+FROM kb_entries
+WHERE tenant_id = (SELECT id FROM tenants WHERE slug = 'demo')
+GROUP BY 1;
+
+-- chunks per article (avg ~2-5 expected for Chatwoot)
+SELECT e.kb_entry_key, count(c.id) AS chunks,
+       count(c.id) FILTER (WHERE c.is_synthetic_question) AS synth_qs
+FROM kb_entries e
+LEFT JOIN kb_chunks c ON c.kb_entry_id = e.id
+WHERE e.tenant_id = (SELECT id FROM tenants WHERE slug = 'demo')
+GROUP BY 1
+ORDER BY chunks DESC
+LIMIT 10;
+```
+
+# Future-source extension
+
+To add a new source (e.g. Wiki, Notion, internal docs):
+
+1. Write `tools/fetch_<source>.py` that produces the canonical shape
+   under `data/kb/<source>/`. Use a different namespace prefix
+   (`kb_entry_key="wiki:<id>"`).
+2. Add a `chatwoot_<source>_token` variable to `terraform-gcp` if it
+   needs auth — same pattern as `chatwoot_help_base_token`.
+3. Run ingest with the new path:
+   `python -m ingest --tenant demo --source /app/data/kb/wiki/`. The
+   namespace is auto-derived from `kb_entry_key`; existing `chatwoot:*`
+   entries are NOT touched (the prefix-scoped diff in `_load_db_entries`
+   isolates each source).
+
+Multiple sources can co-exist on one tenant. The hybrid retrieval CTE
+ranks across them all, so a query can pull the best chunk from
+whichever source had the closest answer.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -519,6 +519,12 @@ services:
       # hf_cache_agent (GigaAM) or hf_cache_vllm: different UIDs would
       # leave cache files unwritable for the neighboring service.
       - hf_cache_retriever:/home/appuser/.cache/huggingface
+      # KB ingestion source dir. Populated on the host by
+      # `tools/fetch_chatwoot_kb.py` (and similar future fetchers);
+      # consumed by `python -m ingest --source /app/data/kb/<source>/`
+      # inside this container. Read-only: the ingest CLI never writes
+      # back, fetchers run from the host.
+      - ../data:/app/data:ro
     # NOT publishing any host port. The retriever is for internal consumption
     # only. Operators needing to curl it from the host can use
     # `docker compose exec retriever curl http://localhost:8002/ready`.

--- a/infra/terraform-gcp/main.tf
+++ b/infra/terraform-gcp/main.tf
@@ -200,10 +200,13 @@ locals {
     llm_api_key            = var.llm_api_key == "" ? "__UNSET__" : var.llm_api_key
     # Optional API seed key. Sentinel + startup script treat __UNSET__ as
     # empty so downstream compose falls back to defaults.
-    seed_demo_api_key    = var.seed_demo_api_key == "" ? "__UNSET__" : var.seed_demo_api_key
+    seed_demo_api_key        = var.seed_demo_api_key == "" ? "__UNSET__" : var.seed_demo_api_key
     agent_internal_token     = var.agent_internal_token == "" ? "__UNSET__" : var.agent_internal_token
     retriever_internal_token = var.retriever_internal_token == "" ? "__UNSET__" : var.retriever_internal_token
     admin_api_key            = var.admin_api_key == "" ? "__UNSET__" : var.admin_api_key
+    # Optional Chatwoot ingestion bearer token — sentinel + startup script
+    # write empty into .env when unset so the fetch tool stays opt-in.
+    chatwoot_help_base_token = var.chatwoot_help_base_token == "" ? "__UNSET__" : var.chatwoot_help_base_token
   }
 }
 
@@ -253,19 +256,19 @@ data "google_compute_image" "dlvm" {
 
 locals {
   startup_script = templatefile("${path.module}/startup_script.sh", {
-    git_repo           = var.git_repo
-    git_ref            = var.git_ref
+    git_repo            = var.git_repo
+    git_ref             = var.git_ref
     image_tag           = var.image_tag
     tts_preload_engines = var.tts_preload_engines
-    project_name       = var.project_name
-    region             = var.region
-    livekit_public_url = local.livekit_public_url
-    tls_enabled        = local.tls_enabled
-    domain             = var.domain
-    tls_email          = var.tls_email
-    secret_prefix      = "${var.project_name}-"
-    llm_base_url       = var.llm_base_url
-    llm_model          = var.llm_model
+    project_name        = var.project_name
+    region              = var.region
+    livekit_public_url  = local.livekit_public_url
+    tls_enabled         = local.tls_enabled
+    domain              = var.domain
+    tls_email           = var.tls_email
+    secret_prefix       = "${var.project_name}-"
+    llm_base_url        = var.llm_base_url
+    llm_model           = var.llm_model
   })
 }
 

--- a/infra/terraform-gcp/startup_script.sh
+++ b/infra/terraform-gcp/startup_script.sh
@@ -186,6 +186,11 @@ if [ "$ADMIN_API_KEY" = "__UNSET__" ]; then
   ADMIN_API_KEY=""
 fi
 
+CHATWOOT_HELP_BASE_TOKEN=$(secret_get chatwoot_help_base_token)
+if [ "$CHATWOOT_HELP_BASE_TOKEN" = "__UNSET__" ]; then
+  CHATWOOT_HELP_BASE_TOKEN=""
+fi
+
 # -----------------------------------------------------------------------------
 # 3. Clone the app repo.
 # -----------------------------------------------------------------------------
@@ -248,6 +253,9 @@ umask 077
   printf 'RETRIEVER_URL=http://retriever:8002\n'
   # Master admin key — empty disables the /v1/admin/* surface.
   printf 'ADMIN_API_KEY=%s\n' "$ADMIN_API_KEY"
+  # Chatwoot help-base bearer token — consumed by tools/fetch_chatwoot_kb.py
+  # at ingest time. Empty leaves Chatwoot ingestion disabled.
+  printf 'CHATWOOT_HELP_BASE_TOKEN=%s\n' "$CHATWOOT_HELP_BASE_TOKEN"
   # The demo SPA embeds this key. Default to the seeded 'demo' tenant
   # key so a fresh terraform apply gives a working SPA out of the box.
   # Rotate by editing the tenant's api_keys rows via SQL.

--- a/infra/terraform-gcp/terraform.tfvars.example
+++ b/infra/terraform-gcp/terraform.tfvars.example
@@ -126,6 +126,15 @@ seed_demo_api_key = ""  # e.g. "tk_0123...abcd"
 retriever_internal_token = ""  # auto-generated when empty
 
 # -----------------------------------------------------------------------------
+# Chatwoot help-base ingestion (optional)
+#
+# Bearer token for GET https://chatwoot.arizona-rp.com/api-help-base/get.
+# Consumed by tools/fetch_chatwoot_kb.py (one-shot or scheduled fetch into
+# data/kb/<project>/). Empty = disabled.
+# -----------------------------------------------------------------------------
+chatwoot_help_base_token = ""
+
+# -----------------------------------------------------------------------------
 # Access
 # -----------------------------------------------------------------------------
 allowed_app_cidr = "0.0.0.0/0"

--- a/infra/terraform-gcp/variables.tf
+++ b/infra/terraform-gcp/variables.tf
@@ -367,4 +367,9 @@ variable "chatwoot_help_base_token" {
   type        = string
   sensitive   = true
   default     = ""
+
+  validation {
+    condition     = length(var.chatwoot_help_base_token) == 0 || length(var.chatwoot_help_base_token) >= 32
+    error_message = "chatwoot_help_base_token must be either empty (disabled) or at least 32 characters. Mirrors the strength bar applied to postgres_password and livekit_api_secret."
+  }
 }

--- a/infra/terraform-gcp/variables.tf
+++ b/infra/terraform-gcp/variables.tf
@@ -350,3 +350,21 @@ variable "admin_api_key" {
   sensitive   = true
   default     = ""
 }
+
+# -----------------------------------------------------------------------------
+# Chatwoot help-base ingestion (optional)
+#
+# Bearer token for `GET https://chatwoot.arizona-rp.com/api-help-base/get`,
+# consumed by `tools/fetch_chatwoot_kb.py` (one-shot or scheduled fetch
+# that dumps articles under `data/kb/<project>/`). Stored in Secret Manager
+# alongside the other app secrets and projected into infra/.env as
+# `CHATWOOT_HELP_BASE_TOKEN`. Empty disables the integration — fetch script
+# refuses to run without the token.
+# -----------------------------------------------------------------------------
+
+variable "chatwoot_help_base_token" {
+  description = "Bearer token for the Chatwoot help-base API. Empty = disable Chatwoot KB ingestion."
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/scripts/refresh_kb.sh
+++ b/scripts/refresh_kb.sh
@@ -32,6 +32,21 @@ set -euo pipefail
 TENANT="${1:-demo}"
 PROJECT="${2:-arizona}"
 
+# Validate the positional args before they flow into filesystem paths
+# and python3 invocations. The strict alphabet (letters/digits/dot/dash/
+# underscore) blocks shell metacharacters, single-quotes (which would
+# break out of the python3 -c string literal below), path separators,
+# and whitespace. Cron entries on the VM use fixed args; this guard
+# protects ad-hoc operator invocations + future automation.
+if [[ ! "${TENANT}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "refresh_kb: invalid TENANT ${TENANT@Q} — must match [A-Za-z0-9._-]+" >&2
+    exit 2
+fi
+if [[ ! "${PROJECT}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "refresh_kb: invalid PROJECT ${PROJECT@Q} — must match [A-Za-z0-9._-]+" >&2
+    exit 2
+fi
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENV_FILE="${REPO_ROOT}/infra/.env"
 DATA_DIR="${REPO_ROOT}/data/kb/${PROJECT}"
@@ -56,7 +71,7 @@ if [[ -z "${CHATWOOT_HELP_BASE_TOKEN:-}" ]]; then
     exit 2
 fi
 
-echo "refresh_kb: phase=fetch project=${PROJECT}"
+echo "refresh_kb: phase=fetch project=${PROJECT}" >&2
 if ! python3 "${REPO_ROOT}/tools/fetch_chatwoot_kb.py" \
         --project "${PROJECT}" \
         --out-dir "${DATA_DIR}"; then
@@ -73,18 +88,33 @@ if [[ ! -f "${MANIFEST}" ]]; then
     echo "refresh_kb: manifest absent at ${MANIFEST} — fetch produced no output" >&2
     exit 2
 fi
-COUNT="$(python3 -c "import json; print(json.load(open('${MANIFEST}'))['count'])")"
-if [[ "${COUNT}" == "0" ]]; then
+# Pass MANIFEST as argv[1] rather than embedding it into the python -c
+# source string. Inline interpolation would expose the script to shell-
+# to-Python injection if PROJECT ever contained a single-quote (now
+# impossible thanks to the regex guard above, but the argv form removes
+# the risk class entirely and survives future regex edits). Capturing
+# the exit status separately keeps ``set -e`` honest — bash does NOT
+# propagate non-zero exits from command-substitution-into-assignment
+# even with -e + -o pipefail.
+if ! COUNT="$(python3 -c '
+import json
+import sys
+print(json.load(open(sys.argv[1]))["count"])
+' "${MANIFEST}")"; then
+    echo "refresh_kb: failed to read count from ${MANIFEST}" >&2
+    exit 2
+fi
+if [[ -z "${COUNT}" || "${COUNT}" == "0" ]]; then
     echo "refresh_kb: upstream returned 0 articles — refusing to run ingest" >&2
     exit 2
 fi
-echo "refresh_kb: phase=fetch ok count=${COUNT}"
+echo "refresh_kb: phase=fetch ok count=${COUNT}" >&2
 
 # The ingest step runs INSIDE the retriever container so it reuses the
 # already-loaded BGE-M3 embedder (saves ~6s of cold load per run) and
 # inherits DB credentials from the container env. The data dir is
 # bind-mounted at /app/data (see infra/docker-compose.yml).
-echo "refresh_kb: phase=ingest tenant=${TENANT} namespace=chatwoot"
+echo "refresh_kb: phase=ingest tenant=${TENANT} namespace=chatwoot" >&2
 INGEST_CMD=(
     docker compose
     --env-file "${ENV_FILE}"
@@ -121,4 +151,4 @@ if ! "${INGEST_CMD[@]}"; then
     exit 3
 fi
 
-echo "refresh_kb: phase=ingest ok"
+echo "refresh_kb: phase=ingest ok" >&2

--- a/scripts/refresh_kb.sh
+++ b/scripts/refresh_kb.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# refresh_kb.sh — fetch the Chatwoot help-base feed and run KB ingestion.
+#
+# Designed to be cron-callable. Logs a single-line JSON record per phase
+# to stdout (parseable by ops grep / log aggregator) and full diagnostic
+# loguru output to stderr.
+#
+# Usage:
+#   ./scripts/refresh_kb.sh              # default: tenant=demo, project=arizona
+#   ./scripts/refresh_kb.sh demo arizona # explicit
+#
+# Exit codes:
+#   0   Both fetch and ingest succeeded.
+#   2   Fetch step failed (network / auth / API). DB unchanged.
+#   3   Ingest step failed or partial-success. Some KB drift may have
+#       landed; the next run resumes from where this one stopped.
+#
+# Requirements on the host:
+#   - infra/.env with CHATWOOT_HELP_BASE_TOKEN set (written by
+#     terraform-gcp's startup_script.sh).
+#   - python3 in $PATH (any 3.10+ — the fetch script is stdlib-only).
+#   - docker compose with a healthy `retriever` container (the
+#     ingest step runs inside it).
+#
+# To wire as a daily cron on the VM:
+#   sudo crontab -e
+#   0 4 * * * /opt/project-800ms/scripts/refresh_kb.sh demo arizona >> \
+#       /var/log/project-800ms-kb-refresh.log 2>&1
+
+set -euo pipefail
+
+TENANT="${1:-demo}"
+PROJECT="${2:-arizona}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${REPO_ROOT}/infra/.env"
+DATA_DIR="${REPO_ROOT}/data/kb/${PROJECT}"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+    echo "refresh_kb: missing ${ENV_FILE} — bootstrap the VM first." >&2
+    exit 2
+fi
+
+# Source the .env to pull CHATWOOT_HELP_BASE_TOKEN into this shell. The
+# `set -a` / `set +a` pair auto-exports each assignment so it crosses
+# the python3 boundary; otherwise the var would only exist in the
+# current shell and the fetch script would see it empty.
+set -a
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+set +a
+
+if [[ -z "${CHATWOOT_HELP_BASE_TOKEN:-}" ]]; then
+    echo "refresh_kb: CHATWOOT_HELP_BASE_TOKEN is empty in ${ENV_FILE}." >&2
+    echo "             Set chatwoot_help_base_token in terraform.tfvars and apply." >&2
+    exit 2
+fi
+
+echo "refresh_kb: phase=fetch project=${PROJECT}"
+if ! python3 "${REPO_ROOT}/tools/fetch_chatwoot_kb.py" \
+        --project "${PROJECT}" \
+        --out-dir "${DATA_DIR}"; then
+    echo "refresh_kb: fetch step failed" >&2
+    exit 2
+fi
+
+# Sanity check: the manifest should exist and report >0 articles. An
+# upstream auth flip can return success with zero articles, which the
+# ingest step's mass-deletion safeguard would catch — but we surface
+# the empty case here so the operator sees a clear log line.
+MANIFEST="${DATA_DIR}/_manifest.json"
+if [[ ! -f "${MANIFEST}" ]]; then
+    echo "refresh_kb: manifest absent at ${MANIFEST} — fetch produced no output" >&2
+    exit 2
+fi
+COUNT="$(python3 -c "import json; print(json.load(open('${MANIFEST}'))['count'])")"
+if [[ "${COUNT}" == "0" ]]; then
+    echo "refresh_kb: upstream returned 0 articles — refusing to run ingest" >&2
+    exit 2
+fi
+echo "refresh_kb: phase=fetch ok count=${COUNT}"
+
+# The ingest step runs INSIDE the retriever container so it reuses the
+# already-loaded BGE-M3 embedder (saves ~6s of cold load per run) and
+# inherits DB credentials from the container env. The data dir is
+# bind-mounted at /app/data (see infra/docker-compose.yml).
+echo "refresh_kb: phase=ingest tenant=${TENANT} namespace=chatwoot"
+INGEST_CMD=(
+    docker compose
+    --env-file "${ENV_FILE}"
+    -f "${REPO_ROOT}/infra/docker-compose.yml"
+    exec -T retriever
+    uv run python -m ingest
+    --tenant "${TENANT}"
+    --source "/app/data/kb/${PROJECT}/"
+    --mode incremental
+)
+
+# Apply prod overlay when present — same pattern the startup script uses.
+if [[ -f "${REPO_ROOT}/infra/docker-compose.prod.yml" ]]; then
+    INGEST_CMD=(
+        docker compose
+        --env-file "${ENV_FILE}"
+        -f "${REPO_ROOT}/infra/docker-compose.yml"
+        -f "${REPO_ROOT}/infra/docker-compose.prod.yml"
+        exec -T retriever
+        uv run python -m ingest
+        --tenant "${TENANT}"
+        --source "/app/data/kb/${PROJECT}/"
+        --mode incremental
+    )
+fi
+
+if ! "${INGEST_CMD[@]}"; then
+    EXIT=$?
+    if [[ "${EXIT}" == "75" ]]; then
+        echo "refresh_kb: ingest reported partial success — see retriever logs" >&2
+        exit 3
+    fi
+    echo "refresh_kb: ingest failed (exit ${EXIT})" >&2
+    exit 3
+fi
+
+echo "refresh_kb: phase=ingest ok"

--- a/services/retriever/chunker.py
+++ b/services/retriever/chunker.py
@@ -1,0 +1,281 @@
+"""Markdown-aware chunker for KB ingestion.
+
+Splits a Russian Markdown article into retrievable chunks. The unique key
+on ``kb_chunks`` is ``(tenant_id, kb_entry_id, section)``, so the chunker
+must produce a stable, unique ``section`` per chunk of the same entry. We
+use the heading path joined with " > " (e.g. ``"Линия наград > Аксессуары"``)
+and disambiguate within-section overflow with a numeric suffix.
+
+The Chatwoot help-base feed is the immediate consumer. Articles look like::
+
+    # Title
+    [intro paragraphs]
+
+    ## H2 section
+    [paragraphs, lists, images]
+
+    ### H3 subsection
+    [...]
+
+The chunker:
+
+1. Strips image references and bare placeholder URLs that would otherwise
+   smear the embedding with low-information tokens.
+2. Splits on H2 / H3 headings — H1 is treated as the article title and
+   not a section break (only one H1 expected).
+3. Within a section, if content exceeds ``MAX_CHARS``, splits further on
+   paragraph boundaries with overlap.
+4. Falls back to a single ``section=None`` chunk when the article has
+   no H2 / H3 structure.
+
+Empty sections (just headings, no body) are dropped — embedding a heading
+on its own dilutes the index without adding recall.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+# Tunable size constants. Picked for BGE-M3 (8192-token cap, ~5K Russian
+# chars) with comfortable headroom and enough context per chunk to support
+# multi-fact answers. Overlap stitches paragraphs together so a question
+# whose answer straddles a chunk boundary still hits at least one chunk.
+MAX_CHARS = 1500
+OVERLAP_CHARS = 150
+# Below this, a chunk almost certainly carries no useful retrieval signal
+# (a stray "Note:" leftover, a single short sentence after image-stripping).
+# Set to a length that still admits a meaningful Russian fact ("Цена 5000$.")
+# but rejects fragments. The "always emit at least one chunk" fallback in
+# `chunk_article` overrides this for tiny-but-non-empty articles.
+MIN_CHARS = 20
+
+# H2 / H3 heading detection. H1 is reserved for the article title and not
+# treated as a section break. We deliberately do NOT match H4+ — deeper
+# nesting in Chatwoot articles is rare and treating it as a leaf section
+# blows up chunk count without recall benefit.
+_H2_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+_H3_RE = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
+_HEADING_RE = re.compile(r"^(#{2,3})\s+(.+?)\s*$", re.MULTILINE)
+
+# Image / blob noise filter. Chatwoot exports rails active_storage redirect
+# URLs (200+ chars of opaque base64) which contribute no semantic signal
+# to retrieval. Replace ``![alt](url)`` with ``[image: alt]`` when alt-text
+# carries information; drop entirely when alt is empty.
+_IMG_RE = re.compile(r"!\[([^\]]*)\]\([^)]*\)")
+# Bare ``<https://...>`` autolinks — useful as anchor text when the URL is
+# meaningful to the user, but Chatwoot uses this for raw video links that
+# add no recall signal. Keep as-is; the hybrid lexical index can still
+# match the URL token if a user actually asks "what's the YouTube link".
+
+
+@dataclass(frozen=True)
+class Chunk:
+    """A single retrievable unit, before embedding.
+
+    ``section`` is ``None`` only when the article has no H2/H3 headings
+    (a flat-prose article). The DB unique key ``(tenant_id, kb_entry_id,
+    section) NULLS NOT DISTINCT`` guarantees at most one such row per
+    entry — the chunker enforces this by emitting a single chunk for
+    headingless articles.
+    """
+
+    section: str | None
+    content: str
+
+
+def _strip_images(text: str) -> str:
+    """Replace ``![alt](url)`` with ``[image: alt]`` (or drop empty-alt)."""
+
+    def _repl(match: re.Match[str]) -> str:
+        alt = match.group(1).strip()
+        return f"[image: {alt}]" if alt else ""
+
+    return _IMG_RE.sub(_repl, text)
+
+
+def _normalise(text: str) -> str:
+    """Collapse runs of blank lines, trim trailing whitespace per line.
+
+    Also strips H1 lines: the article title is carried separately on
+    ``kb_entries.title``, and including the H1 in chunk content would
+    double-weight the title in retrieval (lexical tsvector AND embedding
+    AND title column all touch it).
+    """
+    text = _strip_images(text)
+    # Drop H1 lines entirely — Chatwoot articles usually have one H1
+    # paraphrasing the article title, so it's pure duplication for our
+    # purposes. Multiple H1s are rare; strip them all defensively.
+    text = re.sub(r"^#\s+.*$", "", text, flags=re.MULTILINE)
+    # Trim trailing whitespace on every line so a Chatwoot edit that only
+    # adds/removes spaces at line ends doesn't trigger a re-embed.
+    lines = [ln.rstrip() for ln in text.splitlines()]
+    text = "\n".join(lines)
+    # Collapse 3+ consecutive newlines down to 2 — preserves paragraph
+    # breaks while killing the formatting noise rendered Markdown emits.
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _split_long(content: str, *, section: str | None) -> Iterable[Chunk]:
+    """Split a long section into MAX_CHARS-sized pieces with overlap.
+
+    Splits on paragraph boundaries (blank lines) when possible to keep
+    each chunk semantically intact. If a single paragraph already
+    exceeds MAX_CHARS, it gets character-sliced with overlap — rare in
+    practice (Chatwoot articles use plenty of structure) but the safety
+    net is required.
+    """
+    paragraphs = [p.strip() for p in re.split(r"\n{2,}", content) if p.strip()]
+    if not paragraphs:
+        return
+
+    # Greedy pack paragraphs into chunks until adding the next paragraph
+    # would exceed MAX_CHARS. Overlap is a tail of the previous chunk
+    # (last OVERLAP_CHARS chars), prepended to the next.
+    current = ""
+    part = 1
+    for para in paragraphs:
+        # Single paragraph exceeds the cap — character-slice it.
+        if len(para) > MAX_CHARS:
+            if current:
+                yield Chunk(_section_with_part(section, part), current.strip())
+                part += 1
+                current = ""
+            for slice_text in _char_slices(para):
+                yield Chunk(_section_with_part(section, part), slice_text)
+                part += 1
+            continue
+
+        # Adding this paragraph fits — extend current.
+        if len(current) + len(para) + 2 <= MAX_CHARS:
+            current = (current + "\n\n" + para) if current else para
+            continue
+
+        # Otherwise, flush current and start a new chunk seeded with overlap.
+        if current:
+            yield Chunk(_section_with_part(section, part), current.strip())
+            part += 1
+            tail = current[-OVERLAP_CHARS:].lstrip()
+            # Avoid splitting mid-word in the overlap by trimming back to
+            # the next whitespace if possible.
+            ws = tail.find(" ")
+            if 0 < ws < OVERLAP_CHARS // 2:
+                tail = tail[ws + 1 :]
+            current = (tail + "\n\n" + para) if tail else para
+        else:
+            current = para
+
+    if current and len(current.strip()) >= MIN_CHARS:
+        yield Chunk(_section_with_part(section, part), current.strip())
+
+
+def _char_slices(text: str) -> Iterable[str]:
+    """Last-resort slicer for paragraphs that exceed MAX_CHARS on their own."""
+    step = MAX_CHARS - OVERLAP_CHARS
+    pos = 0
+    while pos < len(text):
+        end = min(pos + MAX_CHARS, len(text))
+        yield text[pos:end].strip()
+        if end == len(text):
+            break
+        pos += step
+
+
+def _section_with_part(section: str | None, part: int) -> str | None:
+    """Append ``" #N"`` to disambiguate overflow chunks within one section.
+
+    The first chunk keeps the bare section (or ``None``) so the unique
+    key ``(tenant_id, kb_entry_id, section) NULLS NOT DISTINCT`` admits
+    exactly one row per article-section. Subsequent overflow parts get a
+    synthetic ``"#N"`` (or ``"<section> #N"``) suffix so they don't
+    collide on the unique key.
+    """
+    if part == 1:
+        return section
+    if section is None:
+        return f"#{part}"
+    return f"{section} #{part}"
+
+
+def _split_by_headings(text: str) -> list[tuple[str | None, str]]:
+    """Split content on H2 / H3 boundaries.
+
+    Returns a list of ``(section_path, body)`` pairs in document order.
+    Content before the first heading is emitted with ``section=None`` —
+    callers treat that as the article preamble.
+    """
+    matches = list(_HEADING_RE.finditer(text))
+    if not matches:
+        return [(None, text)]
+
+    out: list[tuple[str | None, str]] = []
+    # Preamble (before the first heading).
+    first = matches[0]
+    preamble = text[: first.start()].strip()
+    if preamble:
+        out.append((None, preamble))
+
+    # Track the current H2 so an H3 can be reported as "H2 > H3".
+    current_h2: str | None = None
+    for i, match in enumerate(matches):
+        level = len(match.group(1))  # 2 or 3
+        title = match.group(2).strip()
+        body_start = match.end()
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[body_start:body_end].strip()
+
+        if level == 2:
+            current_h2 = title
+            section = title
+        else:  # level == 3
+            section = f"{current_h2} > {title}" if current_h2 else title
+
+        if body:
+            out.append((section, body))
+    return out
+
+
+def chunk_article(*, title: str, content: str) -> list[Chunk]:
+    """Chunk a single article into retrievable pieces.
+
+    Args:
+        title: The article title (H1). Reused for every chunk's
+            ``kb_chunks.title`` column at INSERT time, but NOT prepended
+            to the chunk content here — keeping it out lets the lexical
+            index reflect only the chunk's actual content while the
+            generated tsvector concatenates ``title`` + ``content`` at
+            the SQL layer (see migration 0004).
+        content: The full article body, Markdown.
+
+    Returns:
+        A list of ``Chunk`` instances. Always non-empty for non-trivial
+        input; an article whose normalised body is shorter than
+        ``MIN_CHARS`` returns a single chunk anyway (rather than
+        skipping the entry entirely) so the operator sees something
+        for every kb_entry — silent zero-chunk articles would surprise
+        on the dashboard.
+    """
+    del title  # see docstring — caller stamps title on the kb_chunks row.
+    body = _normalise(content)
+    if not body:
+        return []
+
+    chunks: list[Chunk] = []
+    sections = _split_by_headings(body)
+    has_headings = any(section is not None for section, _ in sections)
+
+    for section, section_body in sections:
+        if len(section_body) <= MAX_CHARS:
+            chunks.append(Chunk(section if has_headings else None, section_body))
+        else:
+            chunks.extend(_split_long(section_body, section=section if has_headings else None))
+
+    # Drop chunks too small to carry signal, but never return an empty
+    # list for an article that had any content — keep at least the
+    # longest chunk as the article's representation.
+    survivors = [c for c in chunks if len(c.content) >= MIN_CHARS]
+    if survivors:
+        return survivors
+    return [max(chunks, key=lambda c: len(c.content))] if chunks else []

--- a/services/retriever/chunker.py
+++ b/services/retriever/chunker.py
@@ -55,8 +55,6 @@ MIN_CHARS = 20
 # treated as a section break. We deliberately do NOT match H4+ — deeper
 # nesting in Chatwoot articles is rare and treating it as a leaf section
 # blows up chunk count without recall benefit.
-_H2_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
-_H3_RE = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
 _HEADING_RE = re.compile(r"^(#{2,3})\s+(.+?)\s*$", re.MULTILINE)
 
 # Image / blob noise filter. Chatwoot exports rails active_storage redirect
@@ -163,7 +161,15 @@ def _split_long(content: str, *, section: str | None) -> Iterable[Chunk]:
             ws = tail.find(" ")
             if 0 < ws < OVERLAP_CHARS // 2:
                 tail = tail[ws + 1 :]
-            current = (tail + "\n\n" + para) if tail else para
+            # Only seed with overlap if the combined length stays within
+            # MAX_CHARS. Otherwise drop the overlap — preserving the
+            # MAX_CHARS bound matters more than overlap continuity, and
+            # tail+\n\n+para could otherwise produce a chunk up to
+            # OVERLAP_CHARS + 2 + MAX_CHARS chars, busting the bound.
+            if tail and len(tail) + 2 + len(para) <= MAX_CHARS:
+                current = tail + "\n\n" + para
+            else:
+                current = para
         else:
             current = para
 

--- a/services/retriever/ingest.py
+++ b/services/retriever/ingest.py
@@ -50,17 +50,21 @@ import argparse
 import asyncio
 import hashlib
 import json
+import re
 import sys
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from loguru import logger
 from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from chunker import chunk_article
 
 # Exit codes per ``contracts/ingest.cli.md``.
 EXIT_OK = 0
@@ -77,6 +81,17 @@ EXIT_PARTIAL_SUCCESS = 75
 # tiny KBs (<= 4 entries) aren't blocked by random-looking ratios.
 MASS_DELETION_THRESHOLD = 0.25
 MASS_DELETION_FLOOR = 4
+
+# Namespace prefix sanity guard. A namespace is the segment before the
+# first ``:`` in ``kb_entry_key`` and flows verbatim into ``LIKE
+# :prefix`` against ``kb_entries.kb_entry_key``. Postgres treats ``%``
+# and ``_`` in the bound value as LIKE wildcards even though SQL
+# parameter binding protects against syntactic injection — a hostile
+# (or accidentally exotic) namespace like ``"%"`` would expand
+# ``LIKE "%:%"`` to match every kb_entry_key with ``:`` in it across
+# unrelated namespaces. Clamp the alphabet to letters/digits/dot/dash
+# at parse time so a single feed can never reach across namespaces.
+_NAMESPACE_RE = re.compile(r"^[A-Za-z0-9.-]+$")
 
 
 @dataclass(frozen=True)
@@ -107,13 +122,21 @@ class Plan:
 def _normalise_content(content: str) -> str:
     """Apply the ``content_sha256`` normalisation contract.
 
-    Strips trailing whitespace per line, normalises Windows line endings
-    to Unix, collapses 3+ consecutive newlines, and trims the result.
-    Any richer normalisation (punctuation, diacritics, image stripping)
-    would make trivial edits invisible — see contract section
-    "Idempotency guarantees".
+    Strips NUL bytes (Postgres TEXT rejects them and would otherwise
+    wedge the entire transaction on rollback), normalises Windows line
+    endings to Unix, and trims trailing whitespace per line. Any richer
+    normalisation (punctuation, diacritics, image stripping) would make
+    trivial edits invisible — see contract section "Idempotency
+    guarantees".
     """
     text_stripped = content.replace("\r\n", "\n")
+    if "\x00" in text_stripped:
+        # Postgres TEXT rejects ``\x00``. Stripping silently would hide
+        # an upstream data-quality issue; warn so the operator sees it
+        # in retriever logs and can chase the offending source row.
+        nul_count = text_stripped.count("\x00")
+        text_stripped = text_stripped.replace("\x00", "")
+        logger.warning("ingest.nul_bytes_stripped count={n}", n=nul_count)
     lines = [ln.rstrip() for ln in text_stripped.split("\n")]
     return "\n".join(lines).strip()
 
@@ -163,6 +186,15 @@ def _load_source_dir(source: Path) -> tuple[list[SourceEntry], list[str]]:
             continue
 
         namespace = kb_entry_key.split(":", 1)[0]
+        if not _NAMESPACE_RE.match(namespace):
+            # Reject namespaces that would smuggle SQL LIKE wildcards
+            # (``%``, ``_``) or whitespace into ``_load_db_entries``'s
+            # diff predicate. See _NAMESPACE_RE docstring.
+            errors.append(
+                f"{path.name}: namespace {namespace!r} contains disallowed "
+                "characters — must match [A-Za-z0-9.-]"
+            )
+            continue
         norm_content = _normalise_content(content_raw)
         entries.append(
             SourceEntry(
@@ -287,8 +319,6 @@ async def _upsert_entry_and_chunks(
 
     Returns the number of chunks written (also = embed calls made).
     """
-    from chunker import chunk_article
-
     chunks = chunk_article(title=entry.title, content=entry.content)
 
     # Upsert kb_entry. ON CONFLICT keeps the row id stable across runs
@@ -368,12 +398,16 @@ async def _upsert_entry_and_chunks(
 
 async def _delete_entry(session: AsyncSession, *, tenant_id: UUID, kb_entry_key: str) -> int:
     """Cascade-delete a kb_entry. Returns chunks deleted."""
+    # Both ``c.tenant_id`` and ``e.tenant_id`` are predicated explicitly
+    # — Principle IV defense-in-depth (the JOIN side alone leaves the
+    # tenant scoping implicit through the FK relationship).
     chunks_deleted = (
         await session.execute(
             text(
                 "SELECT count(*) FROM kb_chunks c "
                 "JOIN kb_entries e ON c.kb_entry_id = e.id "
-                "WHERE e.tenant_id = :t AND e.kb_entry_key = :k"
+                "WHERE c.tenant_id = :t AND e.tenant_id = :t "
+                "  AND e.kb_entry_key = :k"
             ),
             {"t": str(tenant_id), "k": kb_entry_key},
         )
@@ -396,7 +430,8 @@ async def _count_chunks_for_entries(
         text(
             "SELECT count(*) FROM kb_chunks c "
             "JOIN kb_entries e ON c.kb_entry_id = e.id "
-            "WHERE e.tenant_id = :t AND e.kb_entry_key = ANY(:keys) "
+            "WHERE c.tenant_id = :t AND e.tenant_id = :t "
+            "  AND e.kb_entry_key = ANY(:keys) "
             "  AND c.is_synthetic_question = FALSE"
         ),
         {"t": str(tenant_id), "keys": kb_entry_keys},
@@ -408,7 +443,7 @@ async def run(
     *,
     tenant_slug: str,
     source: Path,
-    mode: str = "incremental",
+    mode: Literal["incremental", "full"] = "incremental",
     dry_run: bool = False,
     allow_mass_deletion: bool = False,
     skip_synthetic_questions: bool = True,  # synth phase wired up separately
@@ -463,12 +498,21 @@ async def run(
         "parse_errors": parse_errors,
     }
 
-    if not source_entries and not parse_errors:
-        # Empty but valid source dir — nothing to do. The mass-deletion
-        # safeguard would catch this if it tried to delete the existing
-        # KB; we surface it here as a no-op so the operator gets a
-        # consistent summary instead of a SystemExit.
-        logger.warning("source dir is empty: {p}", p=source_path)
+    if not source_entries:
+        # Zero valid source entries — nothing to ingest. Could be an
+        # empty directory (no parse errors) or one where every file
+        # failed validation (parse errors recorded). Either way we
+        # MUST short-circuit before the diff: with no entries, the
+        # plan would compute ``namespace = ""`` and ``LIKE "%"`` would
+        # match every kb_entry across namespaces → mass-delete via
+        # the diff. The mass-deletion safeguard catches that only
+        # when ``len(plan.delete) >= MASS_DELETION_FLOOR``; a tenant
+        # with <= 4 entries would lose them all silently.
+        logger.warning(
+            "source has no valid entries: path={p} parse_errors={n}",
+            p=source_path,
+            n=len(parse_errors),
+        )
         summary["elapsed_ms"] = int((time.perf_counter() - started) * 1000)
         return summary
 
@@ -492,8 +536,10 @@ async def run(
 
         # Mass-deletion safeguard — fires only when there's a meaningful
         # baseline (avoids "I had 2 entries, deleted 1, that's >25%!").
+        # ``>=`` (not ``>``) so a 5-entry KB with 4 deletes (80%)
+        # triggers the guard rather than slipping through the floor.
         if (
-            len(plan.delete) > MASS_DELETION_FLOOR
+            len(plan.delete) >= MASS_DELETION_FLOOR
             and len(db_entries) > 0
             and len(plan.delete) / len(db_entries) > MASS_DELETION_THRESHOLD
             and not allow_mass_deletion
@@ -616,16 +662,38 @@ def main(argv: list[str] | None = None) -> int:
     if args.verbose:
         logger.remove()
         logger.add(sys.stderr, level="DEBUG")
-    summary = asyncio.run(
-        run(
-            tenant_slug=args.tenant,
-            source=Path(args.source),
-            mode=args.mode,
-            dry_run=args.dry_run,
-            allow_mass_deletion=args.allow_mass_deletion,
-            skip_synthetic_questions=args.skip_synthetic_questions,
+    try:
+        summary = asyncio.run(
+            run(
+                tenant_slug=args.tenant,
+                source=Path(args.source),
+                mode=args.mode,
+                dry_run=args.dry_run,
+                allow_mass_deletion=args.allow_mass_deletion,
+                skip_synthetic_questions=args.skip_synthetic_questions,
+            )
         )
-    )
+    except SQLAlchemyError as exc:
+        # DB connectivity / driver / migration-state failures. Per
+        # contract: exit 74, no partial writes (transactions roll back
+        # on the way up). Operator can re-run --mode incremental safely.
+        logger.error(
+            "ingest.upstream_db_failure kind={k} msg={m}",
+            k=type(exc).__name__,
+            m=str(exc)[:200],
+        )
+        return EXIT_UPSTREAM_FAILURE
+    except (RuntimeError, OSError, MemoryError) as exc:
+        # Embedder OOM / CUDA OOM / model-load OS errors all surface as
+        # one of these. Same exit-code semantics as DB failures: it's
+        # an upstream resource problem, not a logic error in this run's
+        # input. The contract calls these out as exit 74.
+        logger.error(
+            "ingest.upstream_resource_failure kind={k} msg={m}",
+            k=type(exc).__name__,
+            m=str(exc)[:200],
+        )
+        return EXIT_UPSTREAM_FAILURE
     print(json.dumps(summary, ensure_ascii=False))
     return EXIT_PARTIAL_SUCCESS if summary.get("parse_errors") else EXIT_OK
 

--- a/services/retriever/ingest.py
+++ b/services/retriever/ingest.py
@@ -52,6 +52,7 @@ import hashlib
 import json
 import sys
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -280,7 +281,7 @@ async def _upsert_entry_and_chunks(
     *,
     tenant_id: UUID,
     entry: SourceEntry,
-    encode_fn: Any,  # async callable str -> list[float]
+    encode_fn: Callable[[str], Awaitable[list[float]]],
 ) -> int:
     """Insert/update a kb_entry and atomically replace its kb_chunks.
 
@@ -411,7 +412,7 @@ async def run(
     dry_run: bool = False,
     allow_mass_deletion: bool = False,
     skip_synthetic_questions: bool = True,  # synth phase wired up separately
-    encode_fn: Any = None,  # injection seam for tests
+    encode_fn: Callable[[str], Awaitable[list[float]]] | None = None,
 ) -> dict[str, Any]:
     """Run an ingest. Returns the summary dict (also used by the CLI
     main() to format stdout).

--- a/services/retriever/ingest.py
+++ b/services/retriever/ingest.py
@@ -1,0 +1,633 @@
+"""KB ingestion CLI — content phase.
+
+Loads a directory of canonical KB-entry JSON files (the shape produced
+by ``tools/fetch_chatwoot_kb.py``), diffs the set against the tenant's
+existing ``kb_entries`` rows, and embeds + upserts the changes. Synthetic
+question generation is a separate phase (see ``synthetic_questions``)
+that runs after the content commit succeeds.
+
+Usage::
+
+    cd services/retriever
+    uv run python -m ingest --tenant demo --source ../../data/kb/arizona/
+
+In production::
+
+    docker compose exec retriever uv run python -m ingest \\
+        --tenant demo --source /app/data/kb/arizona/
+
+Pipeline
+--------
+
+1. Resolve tenant slug → tenant_id, acquire per-tenant advisory lock
+   (so two ingests for the same tenant cannot interleave writes).
+2. Walk source dir, parse each ``*.json`` into a ``SourceEntry``.
+3. Compute SHA-256 over the normalised content for each source entry.
+4. Load existing kb_entries for ``(tenant_id, kb_entry_key LIKE
+   '<namespace>:%')`` so this run only touches entries from the same
+   namespace as the source feed.
+5. Diff source vs DB → ``add`` / ``update`` / ``unchanged`` / ``delete``.
+6. Mass-deletion safeguard: refuse to apply when delete-rate exceeds
+   ``MASS_DELETION_THRESHOLD`` of existing entries, unless
+   ``--allow-mass-deletion`` is passed. Catches an upstream auth flip
+   that returns an empty/partial feed before it nukes the KB.
+7. For each add/update: chunk via ``chunker.chunk_article``, embed
+   each chunk, upsert ``kb_entry`` and replace its ``kb_chunks`` rows
+   atomically (cascade-deletes any prior synthetic-question children
+   so the synth-Q phase can regenerate them on the next pass).
+8. For each delete: cascade-delete the ``kb_entry`` row.
+9. Emit a one-line JSON summary on stdout. Exit codes per the contract.
+
+Embedding cost note: the BGE-M3 model is loaded once via
+``embedder.preload()`` and reused. Single-text encoding is enough at
+71-article scale (~3-5s end-to-end on CPU). Future batching is a
+performance optimisation, not a correctness one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from loguru import logger
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Exit codes per ``contracts/ingest.cli.md``.
+EXIT_OK = 0
+EXIT_BAD_ARGS = 64
+EXIT_PARSE_ERROR = 65
+EXIT_UPSTREAM_FAILURE = 74
+EXIT_PARTIAL_SUCCESS = 75
+
+# Mass-deletion guard: when more than this fraction of existing entries
+# would be deleted in one run, refuse without ``--allow-mass-deletion``.
+# 25% catches the common "upstream returned partial / empty feed" failure
+# while leaving room for legitimate "we removed a bunch of stale articles"
+# operator-driven cleanups. Activates only above MASS_DELETION_FLOOR so
+# tiny KBs (<= 4 entries) aren't blocked by random-looking ratios.
+MASS_DELETION_THRESHOLD = 0.25
+MASS_DELETION_FLOOR = 4
+
+
+@dataclass(frozen=True)
+class SourceEntry:
+    """One article loaded from disk after validation."""
+
+    kb_entry_key: str  # ``"<namespace>:<id>"`` — e.g. ``"chatwoot:116"``
+    title: str
+    content: str  # already normalised
+    content_sha256: str
+    source_uri: str | None
+    metadata: dict[str, Any]
+    namespace: str  # prefix before ``:`` — used to scope the diff
+
+
+@dataclass
+class Plan:
+    """Diff between source dir and DB."""
+
+    add: list[SourceEntry] = field(default_factory=list)
+    update: list[SourceEntry] = field(default_factory=list)
+    unchanged: list[SourceEntry] = field(default_factory=list)
+    # kb_entry_keys present in DB but missing from source.
+    delete: list[str] = field(default_factory=list)
+    namespace: str = ""
+
+
+def _normalise_content(content: str) -> str:
+    """Apply the ``content_sha256`` normalisation contract.
+
+    Strips trailing whitespace per line, normalises Windows line endings
+    to Unix, collapses 3+ consecutive newlines, and trims the result.
+    Any richer normalisation (punctuation, diacritics, image stripping)
+    would make trivial edits invisible — see contract section
+    "Idempotency guarantees".
+    """
+    text_stripped = content.replace("\r\n", "\n")
+    lines = [ln.rstrip() for ln in text_stripped.split("\n")]
+    return "\n".join(lines).strip()
+
+
+def _sha256(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def _load_source_dir(source: Path) -> tuple[list[SourceEntry], list[str]]:
+    """Walk ``source`` for ``*.json`` files, return ``(entries, errors)``.
+
+    Skips ``_manifest.json``. Each entry is validated against the
+    canonical shape; bad entries are reported as parse errors and
+    omitted from the returned list (so a single bad file doesn't
+    abort the whole run — partial-success exit code 75 covers it).
+    """
+    entries: list[SourceEntry] = []
+    errors: list[str] = []
+    if not source.is_dir():
+        errors.append(f"source is not a directory: {source}")
+        return entries, errors
+
+    for path in sorted(source.glob("*.json")):
+        if path.name == "_manifest.json":
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            errors.append(f"{path.name}: {exc}")
+            continue
+
+        try:
+            kb_entry_key = str(payload["kb_entry_key"]).strip()
+            title = str(payload["title"]).strip()
+            content_raw = payload["content"]
+            if not isinstance(content_raw, str):
+                raise TypeError("content must be a string")
+        except (KeyError, TypeError) as exc:
+            errors.append(f"{path.name}: missing/invalid field: {exc}")
+            continue
+
+        if ":" not in kb_entry_key or kb_entry_key.startswith(":"):
+            errors.append(
+                f"{path.name}: kb_entry_key {kb_entry_key!r} missing namespace prefix "
+                "(expected 'namespace:id')"
+            )
+            continue
+
+        namespace = kb_entry_key.split(":", 1)[0]
+        norm_content = _normalise_content(content_raw)
+        entries.append(
+            SourceEntry(
+                kb_entry_key=kb_entry_key,
+                title=title,
+                content=norm_content,
+                content_sha256=_sha256(norm_content),
+                source_uri=payload.get("source_uri"),
+                metadata=payload.get("metadata") or {},
+                namespace=namespace,
+            )
+        )
+    return entries, errors
+
+
+async def _resolve_tenant_id(session: AsyncSession, slug: str) -> UUID:
+    """Look up a tenant by slug. Raises SystemExit(64) on miss.
+
+    Status filter mirrors ``tenants.resolve_tenant`` — only ``active``
+    tenants accept ingest writes. Reusing that module would require
+    a UUID at the call site; the slug-based lookup here keeps the CLI
+    operator-friendly.
+    """
+    row = (
+        await session.execute(
+            text("SELECT id FROM tenants WHERE slug = :slug AND status = 'active'"),
+            {"slug": slug},
+        )
+    ).first()
+    if row is None:
+        logger.error("unknown or non-active tenant slug={slug}", slug=slug)
+        raise SystemExit(EXIT_BAD_ARGS)
+    return row[0]
+
+
+async def _advisory_lock(session: AsyncSession, tenant_id: UUID) -> None:
+    """Acquire a transaction-scoped per-tenant advisory lock.
+
+    Mirrors the contract: ``hash_int8('kb_ingest:' || tenant_id::text)``
+    (``hashtext`` returns int4, but ``pg_advisory_xact_lock`` accepts
+    int4 via implicit cast — same effective key space).
+
+    Two concurrent ingests for the same tenant block here until the
+    first commits; two ingests for different tenants proceed in
+    parallel.
+    """
+    await session.execute(
+        text("SELECT pg_advisory_xact_lock(  hashtext('kb_ingest:' || :tid)::int8)"),
+        {"tid": str(tenant_id)},
+    )
+
+
+async def _load_db_entries(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    namespace: str,
+    mode: str,
+) -> dict[str, dict[str, Any]]:
+    """Return existing kb_entries for the namespace, keyed by kb_entry_key.
+
+    For ``--mode full`` the content_sha256 is masked so the diff treats
+    every entry as changed (forces re-embed). For ``--mode incremental``
+    the real hash is returned so unchanged entries short-circuit.
+    """
+    rows = (
+        (
+            await session.execute(
+                text(
+                    "SELECT id, kb_entry_key, content_sha256 "
+                    "FROM kb_entries "
+                    "WHERE tenant_id = :tid AND kb_entry_key LIKE :prefix"
+                ),
+                {"tid": str(tenant_id), "prefix": f"{namespace}:%"},
+            )
+        )
+        .mappings()
+        .all()
+    )
+    out = {row["kb_entry_key"]: dict(row) for row in rows}
+    if mode == "full":
+        for v in out.values():
+            v["content_sha256"] = "__force_re_embed__"
+    return out
+
+
+def _diff(
+    source: list[SourceEntry],
+    db_entries: dict[str, dict[str, Any]],
+    namespace: str,
+) -> Plan:
+    """Compute add/update/unchanged/delete sets."""
+    plan = Plan(namespace=namespace)
+    src_keys: set[str] = set()
+    for entry in source:
+        src_keys.add(entry.kb_entry_key)
+        if entry.kb_entry_key not in db_entries:
+            plan.add.append(entry)
+        elif db_entries[entry.kb_entry_key]["content_sha256"] != entry.content_sha256:
+            plan.update.append(entry)
+        else:
+            plan.unchanged.append(entry)
+    for db_key in db_entries:
+        if db_key not in src_keys:
+            plan.delete.append(db_key)
+    return plan
+
+
+def _vector_literal(v: list[float]) -> str:
+    """Format a 1024-dim list as the pgvector text representation."""
+    return "[" + ",".join(f"{x:.10g}" for x in v) + "]"
+
+
+async def _upsert_entry_and_chunks(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    entry: SourceEntry,
+    encode_fn: Any,  # async callable str -> list[float]
+) -> int:
+    """Insert/update a kb_entry and atomically replace its kb_chunks.
+
+    Returns the number of chunks written (also = embed calls made).
+    """
+    from chunker import chunk_article
+
+    chunks = chunk_article(title=entry.title, content=entry.content)
+
+    # Upsert kb_entry. ON CONFLICT keeps the row id stable across runs
+    # (subsequent updates only bump content_sha256 + updated_at).
+    row = (
+        await session.execute(
+            text(
+                "INSERT INTO kb_entries "
+                "  (tenant_id, kb_entry_key, title, source_uri, content_sha256) "
+                "VALUES (:t, :k, :title, :uri, :sha) "
+                "ON CONFLICT (tenant_id, kb_entry_key) DO UPDATE SET "
+                "  title = EXCLUDED.title, "
+                "  source_uri = EXCLUDED.source_uri, "
+                "  content_sha256 = EXCLUDED.content_sha256, "
+                "  updated_at = now() "
+                "RETURNING id"
+            ),
+            {
+                "t": str(tenant_id),
+                "k": entry.kb_entry_key,
+                "title": entry.title,
+                "uri": entry.source_uri,
+                "sha": entry.content_sha256,
+            },
+        )
+    ).first()
+    entry_id = row[0]
+
+    # Replace chunks. The kb_chunks → kb_chunks self-FK has ON DELETE
+    # CASCADE so any synthetic-question children disappear with their
+    # parent — the synth-Q phase will regenerate them.
+    await session.execute(
+        text("DELETE FROM kb_chunks WHERE tenant_id = :t AND kb_entry_id = :eid"),
+        {"t": str(tenant_id), "eid": str(entry_id)},
+    )
+
+    if not chunks:
+        return 0
+
+    # Embed each chunk. Prepending the section path to the embedding
+    # input gives the embedder lexical anchor points for nested topics
+    # ("Линия наград > Аксессуары" + body) without polluting the stored
+    # content column or the lexical tsvector (which is title || content
+    # only).
+    # Use CAST(...) rather than ``::vector`` / ``::jsonb`` because the
+    # double-colon inside a SQLAlchemy ``text()`` collides with the
+    # ``:name`` bind-parameter parser and silently leaves the literal
+    # ``:emb::vector`` in the rendered SQL.
+    insert_sql = text(
+        "INSERT INTO kb_chunks "
+        "  (tenant_id, kb_entry_id, section, title, content, "
+        "   content_sha256, embedding, metadata) "
+        "VALUES (:t, :eid, :section, :title, :content, :sha, "
+        "        CAST(:emb AS vector), CAST(:meta AS jsonb))"
+    )
+    metadata_json = json.dumps(entry.metadata, ensure_ascii=False)
+    written = 0
+    for chunk in chunks:
+        embed_input = f"{chunk.section}\n\n{chunk.content}" if chunk.section else chunk.content
+        embedding = await encode_fn(embed_input)
+        await session.execute(
+            insert_sql,
+            {
+                "t": str(tenant_id),
+                "eid": str(entry_id),
+                "section": chunk.section,
+                "title": entry.title,
+                "content": chunk.content,
+                "sha": _sha256(chunk.content),
+                "emb": _vector_literal(embedding),
+                "meta": metadata_json,
+            },
+        )
+        written += 1
+    return written
+
+
+async def _delete_entry(session: AsyncSession, *, tenant_id: UUID, kb_entry_key: str) -> int:
+    """Cascade-delete a kb_entry. Returns chunks deleted."""
+    chunks_deleted = (
+        await session.execute(
+            text(
+                "SELECT count(*) FROM kb_chunks c "
+                "JOIN kb_entries e ON c.kb_entry_id = e.id "
+                "WHERE e.tenant_id = :t AND e.kb_entry_key = :k"
+            ),
+            {"t": str(tenant_id), "k": kb_entry_key},
+        )
+    ).scalar_one()
+    await session.execute(
+        text("DELETE FROM kb_entries WHERE tenant_id = :t AND kb_entry_key = :k"),
+        {"t": str(tenant_id), "k": kb_entry_key},
+    )
+    return int(chunks_deleted)
+
+
+async def _count_chunks_for_entries(
+    session: AsyncSession, *, tenant_id: UUID, kb_entry_keys: list[str]
+) -> int:
+    """Count the kb_chunks attached to the given entries (for unchanged-
+    chunk reporting)."""
+    if not kb_entry_keys:
+        return 0
+    result = await session.execute(
+        text(
+            "SELECT count(*) FROM kb_chunks c "
+            "JOIN kb_entries e ON c.kb_entry_id = e.id "
+            "WHERE e.tenant_id = :t AND e.kb_entry_key = ANY(:keys) "
+            "  AND c.is_synthetic_question = FALSE"
+        ),
+        {"t": str(tenant_id), "keys": kb_entry_keys},
+    )
+    return int(result.scalar_one())
+
+
+async def run(
+    *,
+    tenant_slug: str,
+    source: Path,
+    mode: str = "incremental",
+    dry_run: bool = False,
+    allow_mass_deletion: bool = False,
+    skip_synthetic_questions: bool = True,  # synth phase wired up separately
+    encode_fn: Any = None,  # injection seam for tests
+) -> dict[str, Any]:
+    """Run an ingest. Returns the summary dict (also used by the CLI
+    main() to format stdout).
+
+    The ``encode_fn`` parameter exists so tests can inject a deterministic
+    stub embedder without paying the BGE-M3 load cost. Production callers
+    should leave it unset; the function lazy-imports ``embedder.encode``
+    and preloads the model on first use.
+    """
+    from db import get_session, set_tenant_scope
+
+    started = time.perf_counter()
+
+    if mode not in {"incremental", "full"}:
+        logger.error("invalid --mode={mode}", mode=mode)
+        raise SystemExit(EXIT_BAD_ARGS)
+
+    source_path = source.expanduser().resolve()
+    source_entries, parse_errors = _load_source_dir(source_path)
+
+    namespaces = {e.namespace for e in source_entries}
+    if len(namespaces) > 1:
+        logger.error(
+            "mixed namespaces in source: {ns} — split feeds into separate "
+            "directories before ingesting",
+            ns=sorted(namespaces),
+        )
+        raise SystemExit(EXIT_PARSE_ERROR)
+    namespace = next(iter(namespaces)) if namespaces else ""
+
+    summary: dict[str, Any] = {
+        "tenant": tenant_slug,
+        "source": str(source_path),
+        "namespace": namespace,
+        "mode": mode,
+        "dry_run": dry_run,
+        "entries": {
+            "seen": len(source_entries),
+            "added": 0,
+            "updated": 0,
+            "unchanged": 0,
+            "deleted": 0,
+        },
+        "chunks": {"added": 0, "deleted": 0, "unchanged": 0},
+        "embed_calls": 0,
+        "synthetic_questions": {"added": 0, "deleted": 0},
+        "rewriter_calls": 0,
+        "parse_errors": parse_errors,
+    }
+
+    if not source_entries and not parse_errors:
+        # Empty but valid source dir — nothing to do. The mass-deletion
+        # safeguard would catch this if it tried to delete the existing
+        # KB; we surface it here as a no-op so the operator gets a
+        # consistent summary instead of a SystemExit.
+        logger.warning("source dir is empty: {p}", p=source_path)
+        summary["elapsed_ms"] = int((time.perf_counter() - started) * 1000)
+        return summary
+
+    # Lazy-import embedder so --help / dry-run with bad args don't pay
+    # the BGE-M3 load cost.
+    if encode_fn is None:
+        from embedder import encode, preload
+
+        await asyncio.to_thread(preload)
+        encode_fn = encode
+
+    async with get_session() as session:
+        tenant_id = await _resolve_tenant_id(session, tenant_slug)
+        await _advisory_lock(session, tenant_id)
+        await set_tenant_scope(session, tenant_id)
+
+        db_entries = await _load_db_entries(
+            session, tenant_id=tenant_id, namespace=namespace, mode=mode
+        )
+        plan = _diff(source_entries, db_entries, namespace)
+
+        # Mass-deletion safeguard — fires only when there's a meaningful
+        # baseline (avoids "I had 2 entries, deleted 1, that's >25%!").
+        if (
+            len(plan.delete) > MASS_DELETION_FLOOR
+            and len(db_entries) > 0
+            and len(plan.delete) / len(db_entries) > MASS_DELETION_THRESHOLD
+            and not allow_mass_deletion
+        ):
+            logger.error(
+                "mass-deletion safeguard fired: would delete {n} of {total} entries "
+                "(>{pct:.0%}). Re-run with --allow-mass-deletion to override.",
+                n=len(plan.delete),
+                total=len(db_entries),
+                pct=MASS_DELETION_THRESHOLD,
+            )
+            raise SystemExit(EXIT_PARTIAL_SUCCESS)
+
+        summary["entries"]["added"] = len(plan.add)
+        summary["entries"]["updated"] = len(plan.update)
+        summary["entries"]["unchanged"] = len(plan.unchanged)
+        summary["entries"]["deleted"] = len(plan.delete)
+
+        if dry_run:
+            # No DB writes — count what would happen and return.
+            summary["chunks"]["unchanged"] = await _count_chunks_for_entries(
+                session,
+                tenant_id=tenant_id,
+                kb_entry_keys=[e.kb_entry_key for e in plan.unchanged],
+            )
+            summary["elapsed_ms"] = int((time.perf_counter() - started) * 1000)
+            return summary
+
+        # Apply add + update via the same code path (UPSERT + replace).
+        for entry in plan.add + plan.update:
+            written = await _upsert_entry_and_chunks(
+                session, tenant_id=tenant_id, entry=entry, encode_fn=encode_fn
+            )
+            summary["chunks"]["added"] += written
+            summary["embed_calls"] += written
+            logger.info(
+                "ingest.entry_written key={k} chunks={n}",
+                k=entry.kb_entry_key,
+                n=written,
+            )
+
+        for kb_entry_key in plan.delete:
+            chunks_lost = await _delete_entry(
+                session, tenant_id=tenant_id, kb_entry_key=kb_entry_key
+            )
+            summary["chunks"]["deleted"] += chunks_lost
+            logger.info(
+                "ingest.entry_deleted key={k} chunks={n}",
+                k=kb_entry_key,
+                n=chunks_lost,
+            )
+
+        summary["chunks"]["unchanged"] = await _count_chunks_for_entries(
+            session,
+            tenant_id=tenant_id,
+            kb_entry_keys=[e.kb_entry_key for e in plan.unchanged],
+        )
+
+    # Synth-Q phase placeholder. Wired up in the next task with its own
+    # transaction so a content commit never depends on the LLM being
+    # available.
+    if not skip_synthetic_questions:
+        # The synth phase is implemented in synthetic_questions.run; left
+        # unimported here so the content-only path has zero LLM coupling.
+        from synthetic_questions import run as synth_run
+
+        synth_summary = await synth_run(tenant_slug=tenant_slug, namespace=namespace)
+        summary["synthetic_questions"]["added"] = synth_summary["added"]
+        summary["synthetic_questions"]["deleted"] = synth_summary["deleted"]
+        summary["rewriter_calls"] = synth_summary["rewriter_calls"]
+
+    summary["elapsed_ms"] = int((time.perf_counter() - started) * 1000)
+    return summary
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m ingest",
+        description=(
+            "Ingest a directory of canonical KB-entry JSON files into a tenant's "
+            "kb_entries / kb_chunks tables. Idempotent on content_sha256."
+        ),
+    )
+    parser.add_argument("--tenant", required=True, help="tenants.slug — must exist + be active")
+    parser.add_argument("--source", required=True, help="path to directory of *.json files")
+    parser.add_argument(
+        "--mode",
+        choices=("incremental", "full"),
+        default="incremental",
+        help="incremental: skip unchanged entries (default). full: re-embed every entry.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the plan without writing to DB or calling the embedder.",
+    )
+    parser.add_argument(
+        "--allow-mass-deletion",
+        action="store_true",
+        help=(
+            f"override the >{int(MASS_DELETION_THRESHOLD * 100)}% delete-rate safeguard "
+            "(use only when intentionally pruning)."
+        ),
+    )
+    parser.add_argument(
+        "--skip-synthetic-questions",
+        action="store_true",
+        help="skip the synthetic-question generation phase (content-only ingest).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="emit per-entry decisions on stderr.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    if args.verbose:
+        logger.remove()
+        logger.add(sys.stderr, level="DEBUG")
+    summary = asyncio.run(
+        run(
+            tenant_slug=args.tenant,
+            source=Path(args.source),
+            mode=args.mode,
+            dry_run=args.dry_run,
+            allow_mass_deletion=args.allow_mass_deletion,
+            skip_synthetic_questions=args.skip_synthetic_questions,
+        )
+    )
+    print(json.dumps(summary, ensure_ascii=False))
+    return EXIT_PARTIAL_SUCCESS if summary.get("parse_errors") else EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/retriever/synthetic_questions.py
+++ b/services/retriever/synthetic_questions.py
@@ -55,8 +55,10 @@ hybrid score; eight oversaturates the index without proportional gain.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
@@ -154,11 +156,18 @@ async def _call_llm(
             resp = await client.post(url, headers=headers, json=payload)
         except httpx.TimeoutException:
             last_error = "timeout"
-            await asyncio.sleep(LLM_BACKOFF_SECONDS[attempt])
+            # Mirror the guard the retry-status branch below uses — never
+            # sleep after the LAST attempt; the loop is about to exit
+            # anyway and the caller is waiting on us. Without this, a
+            # 5-consecutive-failure phase abort wastes ~10s of cumulative
+            # tail-sleeps with no chance of another retry.
+            if attempt < LLM_MAX_ATTEMPTS - 1:
+                await asyncio.sleep(LLM_BACKOFF_SECONDS[attempt])
             continue
         except httpx.HTTPError as exc:
             last_error = type(exc).__name__
-            await asyncio.sleep(LLM_BACKOFF_SECONDS[attempt])
+            if attempt < LLM_MAX_ATTEMPTS - 1:
+                await asyncio.sleep(LLM_BACKOFF_SECONDS[attempt])
             continue
 
         last_status = resp.status_code
@@ -260,7 +269,7 @@ async def run(
     *,
     tenant_slug: str,
     namespace: str,
-    encode_fn: Any | None = None,
+    encode_fn: Callable[[str], Awaitable[list[float]]] | None = None,
     http_client: httpx.AsyncClient | None = None,
 ) -> dict[str, Any]:
     """Run the synthetic-question phase for one tenant + namespace.
@@ -383,6 +392,4 @@ async def run(
 
 
 def _q_sha(question: str) -> str:
-    import hashlib
-
     return hashlib.sha256(question.encode("utf-8")).hexdigest()

--- a/services/retriever/synthetic_questions.py
+++ b/services/retriever/synthetic_questions.py
@@ -66,6 +66,7 @@ from uuid import UUID
 import httpx
 from loguru import logger
 from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 QUESTIONS_PER_CHUNK = 4
@@ -74,6 +75,12 @@ LLM_MAX_TOKENS = 400
 LLM_MAX_ATTEMPTS = 3
 LLM_BACKOFF_SECONDS = (0.5, 1.0, 2.0)
 LLM_RETRY_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
+# Abort the synth phase once this many content chunks in a row have
+# returned no usable questions. Five gives operators a clear "the LLM
+# is genuinely down or the daily quota is exhausted" signal without
+# burning attempts indefinitely; remaining naked chunks resume on
+# the next run via the NOT EXISTS filter.
+LLM_CONSECUTIVE_FAILURE_ABORT = 5
 
 _SYSTEM_PROMPT = (
     "Ты — генератор поисковых запросов для русскоязычного голосового "
@@ -243,7 +250,8 @@ async def _select_naked_chunks(
                     "  AND e.kb_entry_key LIKE :prefix "
                     "  AND NOT EXISTS ("
                     "    SELECT 1 FROM kb_chunks sq "
-                    "    WHERE sq.parent_chunk_id = c.id"
+                    "    WHERE sq.parent_chunk_id = c.id "
+                    "      AND sq.tenant_id = c.tenant_id"
                     "  ) "
                     "ORDER BY c.id"
                 ),
@@ -306,12 +314,18 @@ async def run(
         timeout=httpx.Timeout(LLM_TIMEOUT_S, connect=2.0),
     )
     try:
-        async with get_session() as session:
-            # Resolve tenant inline rather than reusing tenants.resolve_tenant
-            # (which takes a UUID, not a slug). Keeps the synth phase callable
-            # standalone from the CLI without an extra lookup.
+        # Setup phase: resolve tenant + select naked chunks in one short
+        # session, then close it. We deliberately do NOT keep this
+        # session open across the per-chunk loop: a single transaction
+        # spanning all N chunks means a mid-loop exception (embedder
+        # OOM, transient asyncpg disconnect) rolls back every synth
+        # row already inserted. With one transaction per chunk, a
+        # failure on chunk K only loses chunk K's questions; chunks
+        # 0..K-1 are durably committed and chunk K stays naked for the
+        # next run (NOT EXISTS filter picks it up automatically).
+        async with get_session() as setup_session:
             row = (
-                await session.execute(
+                await setup_session.execute(
                     text("SELECT id FROM tenants WHERE slug = :slug AND status = 'active'"),
                     {"slug": tenant_slug},
                 )
@@ -321,68 +335,83 @@ async def run(
                 return summary
             tenant_id: UUID = row[0]
 
-            await set_tenant_scope(session, tenant_id)
-            naked = await _select_naked_chunks(session, tenant_id=tenant_id, namespace=namespace)
-            logger.info(
-                "synth.start tenant={t} namespace={ns} chunks_naked={n}",
-                t=tenant_slug,
-                ns=namespace,
-                n=len(naked),
+            await set_tenant_scope(setup_session, tenant_id)
+            naked = await _select_naked_chunks(
+                setup_session, tenant_id=tenant_id, namespace=namespace
             )
+        logger.info(
+            "synth.start tenant={t} namespace={ns} chunks_naked={n}",
+            t=tenant_slug,
+            ns=namespace,
+            n=len(naked),
+        )
+
+        consecutive_failures = 0
+        for chunk in naked:
+            summary["chunks_touched"] += 1
+            summary["rewriter_calls"] += 1
+            questions = await _call_llm(
+                client,
+                base_url=str(settings.llm_base_url),
+                api_key=settings.llm_api_key,
+                model=settings.rewriter_model,
+                title=chunk.title,
+                section=chunk.section,
+                content=chunk.content,
+            )
+            if not questions:
+                consecutive_failures += 1
+                if consecutive_failures >= LLM_CONSECUTIVE_FAILURE_ABORT:
+                    logger.error(
+                        "synth.aborted_after_consecutive_failures remaining={r}",
+                        r=len(naked) - summary["chunks_touched"],
+                    )
+                    break
+                continue
 
             consecutive_failures = 0
-            for chunk in naked:
-                summary["chunks_touched"] += 1
-                summary["rewriter_calls"] += 1
-                questions = await _call_llm(
-                    client,
-                    base_url=str(settings.llm_base_url),
-                    api_key=settings.llm_api_key,
-                    model=settings.rewriter_model,
-                    title=chunk.title,
-                    section=chunk.section,
-                    content=chunk.content,
-                )
-                if not questions:
-                    consecutive_failures += 1
-                    # If 5 consecutive chunks fail, abort the phase —
-                    # likely the LLM is down or quota is exhausted, no
-                    # value in burning more attempts. Operator gets a
-                    # partial-success summary; next run resumes.
-                    if consecutive_failures >= 5:
-                        logger.error(
-                            "synth.aborted_after_consecutive_failures remaining={r}",
-                            r=len(naked) - summary["chunks_touched"],
-                        )
-                        break
-                    continue
 
-                consecutive_failures = 0
-                # Embed each question; insert as is_synthetic_question=TRUE
-                # with parent_chunk_id pointing at this content chunk.
-                for question in questions:
-                    embedding = await encode_fn(question)
-                    await session.execute(
-                        text(
-                            "INSERT INTO kb_chunks "
-                            "  (tenant_id, kb_entry_id, section, title, "
-                            "   content, content_sha256, embedding, "
-                            "   is_synthetic_question, parent_chunk_id) "
-                            "VALUES (:t, :eid, :section, :title, :content, "
-                            "        :sha, CAST(:emb AS vector), TRUE, :pid)"
-                        ),
-                        {
-                            "t": str(tenant_id),
-                            "eid": str(chunk.kb_entry_id),
-                            "section": chunk.section,
-                            "title": chunk.title,
-                            "content": question,
-                            "sha": _q_sha(question),
-                            "emb": _vector_literal(embedding),
-                            "pid": chunk.id,
-                        },
-                    )
-                    summary["added"] += 1
+            # Per-chunk transaction. If insert fails (FK violation from
+            # a concurrent ingest deleting the parent, transient DB
+            # error, etc.), the wrapping ``except`` swallows it after
+            # the session has rolled back, and we move on. The chunk
+            # remains naked for the next run via the NOT EXISTS filter.
+            try:
+                async with get_session() as session:
+                    await set_tenant_scope(session, tenant_id)
+                    for question in questions:
+                        embedding = await encode_fn(question)
+                        await session.execute(
+                            text(
+                                "INSERT INTO kb_chunks "
+                                "  (tenant_id, kb_entry_id, section, title, "
+                                "   content, content_sha256, embedding, "
+                                "   is_synthetic_question, parent_chunk_id) "
+                                "VALUES (:t, :eid, :section, :title, :content, "
+                                "        :sha, CAST(:emb AS vector), TRUE, :pid)"
+                            ),
+                            {
+                                "t": str(tenant_id),
+                                "eid": str(chunk.kb_entry_id),
+                                "section": chunk.section,
+                                "title": chunk.title,
+                                "content": question,
+                                "sha": _q_sha(question),
+                                "emb": _vector_literal(embedding),
+                                "pid": chunk.id,
+                            },
+                        )
+                # ``async with get_session()`` committed cleanly. Only
+                # now count the questions as added — pre-commit counting
+                # would lie if the transaction rolled back.
+                summary["added"] += len(questions)
+            except SQLAlchemyError as exc:
+                logger.warning(
+                    "synth.chunk_insert_failed chunk_id={cid} kind={k} msg={m}",
+                    cid=chunk.id,
+                    k=type(exc).__name__,
+                    m=str(exc)[:200],
+                )
     finally:
         if own_client:
             await client.aclose()

--- a/services/retriever/synthetic_questions.py
+++ b/services/retriever/synthetic_questions.py
@@ -1,0 +1,388 @@
+"""Synthetic question pass — per-content-chunk paraphrase generation.
+
+Adds rows to ``kb_chunks`` with ``is_synthetic_question = TRUE`` and
+``parent_chunk_id`` pointing at the content chunk they paraphrase. The
+hybrid retrieval CTE returns parent + synthetic-question matches in the
+same scored list, so a user query worded differently from the source
+text can hit a synthetic question's embedding and still pull the right
+parent answer back.
+
+Design notes
+------------
+
+This module is a SEPARATE phase from ingest's content path. The content
+phase commits before this runs, so a rate-limited / down rewriter LLM
+never blocks new content from landing in the DB. On retry, the next
+ingest picks up content chunks that still have no synthetic-question
+children and fills them in.
+
+The "needs synth questions" filter uses the parent_chunk_id self-FK:
+
+    SELECT c.id FROM kb_chunks c
+    WHERE c.tenant_id = $1
+      AND c.is_synthetic_question = FALSE
+      AND c.kb_entry_id IN (... entries with prefix ...)
+      AND NOT EXISTS (
+        SELECT 1 FROM kb_chunks sq
+        WHERE sq.parent_chunk_id = c.id
+      )
+
+When a content chunk is replaced (ingest UPDATE path), its synthetic
+children cascade-delete (ON DELETE CASCADE on parent_chunk_id), so the
+parent is then "naked" again and this phase will regenerate questions
+on the next run.
+
+LLM cost / failure handling
+----------------------------
+
+* One LLM call per content chunk (NOT per synthetic question — the
+  model emits a JSON array of N).
+* Retries 429 / 5xx with exponential backoff (0.5s, 1s, 2s) up to 3
+  attempts. Beyond that the chunk is skipped — partial success is
+  acceptable, the next run picks it up.
+* A persistent failure on every call (LLM down, key rotated, daily
+  quota exhausted) terminates the phase early and surfaces in the
+  summary; content commit is unaffected.
+
+Tunables
+--------
+
+``QUESTIONS_PER_CHUNK = 4`` is the recall/cost compromise from R6
+(specs/002-helper-guide-npc/research.md). Two questions barely move the
+hybrid score; eight oversaturates the index without proportional gain.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+import httpx
+from loguru import logger
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+QUESTIONS_PER_CHUNK = 4
+LLM_TIMEOUT_S = 8.0
+LLM_MAX_TOKENS = 400
+LLM_MAX_ATTEMPTS = 3
+LLM_BACKOFF_SECONDS = (0.5, 1.0, 2.0)
+LLM_RETRY_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+_SYSTEM_PROMPT = (
+    "Ты — генератор поисковых запросов для русскоязычного голосового "
+    "помощника по игре Arizona RP. Тебе дан фрагмент справочной "
+    "статьи. Сгенерируй ровно "
+    f"{QUESTIONS_PER_CHUNK} различных вопросов, на которые этот фрагмент "
+    "даёт ответ.\n\n"
+    "Требования к вопросам:\n"
+    "  - на русском языке;\n"
+    "  - в разговорной форме, как мог бы спросить игрок голосом;\n"
+    "  - 5–15 слов;\n"
+    "  - покрывать разные аспекты фрагмента (без дубликатов);\n"
+    "  - без ссылок на «согласно тексту», «в этой статье» и т.п. — "
+    "вопрос должен быть осмысленным сам по себе.\n\n"
+    'Ответ — строго JSON-объект {"questions": ["...", "..."]}. '
+    "Никаких пояснений, никакого Markdown."
+)
+
+
+@dataclass(frozen=True)
+class _ChunkRow:
+    id: int
+    title: str
+    section: str | None
+    content: str
+    kb_entry_id: UUID
+
+
+def _build_user_prompt(*, title: str, section: str | None, content: str) -> str:
+    """Assemble the per-chunk user prompt.
+
+    Keeps title + section + content in distinct labelled blocks so the
+    model can differentiate "what is the article about" vs "which subsection
+    is this quoting" — important for nested patch-note articles.
+    """
+    section_line = f"Раздел: {section}\n" if section else ""
+    return f"Заголовок статьи: {title}\n{section_line}Текст:\n{content}"
+
+
+async def _call_llm(
+    client: httpx.AsyncClient,
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    title: str,
+    section: str | None,
+    content: str,
+) -> list[str]:
+    """Generate N questions for one chunk with bounded retries.
+
+    Returns the parsed list, or an empty list if every attempt failed.
+    The empty-list contract lets the caller proceed on the next chunk
+    without forcing a phase-level abort — the chunk simply has no
+    synthetic children for this run.
+    """
+    url = f"{base_url.rstrip('/')}/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": _build_user_prompt(title=title, section=section, content=content),
+            },
+        ],
+        "response_format": {"type": "json_object"},
+        "max_tokens": LLM_MAX_TOKENS,
+        "temperature": 0.4,  # mild diversity across the N questions
+    }
+
+    last_status: int | None = None
+    last_error: str | None = None
+    for attempt in range(LLM_MAX_ATTEMPTS):
+        try:
+            resp = await client.post(url, headers=headers, json=payload)
+        except httpx.TimeoutException:
+            last_error = "timeout"
+            await asyncio.sleep(LLM_BACKOFF_SECONDS[attempt])
+            continue
+        except httpx.HTTPError as exc:
+            last_error = type(exc).__name__
+            await asyncio.sleep(LLM_BACKOFF_SECONDS[attempt])
+            continue
+
+        last_status = resp.status_code
+        if resp.status_code in LLM_RETRY_STATUSES and attempt < LLM_MAX_ATTEMPTS - 1:
+            await asyncio.sleep(LLM_BACKOFF_SECONDS[attempt])
+            continue
+        if resp.status_code >= 400:
+            logger.warning(
+                "synth.llm_non_2xx status={s} attempt={a}",
+                s=resp.status_code,
+                a=attempt + 1,
+            )
+            return []
+
+        try:
+            content_str = resp.json()["choices"][0]["message"]["content"]
+            parsed = json.loads(content_str)
+        except (KeyError, IndexError, ValueError) as exc:
+            logger.warning("synth.llm_parse_error err={e}", e=type(exc).__name__)
+            return []
+
+        questions: list[str] = []
+        if isinstance(parsed, dict) and "questions" in parsed:
+            raw = parsed["questions"]
+            if isinstance(raw, list):
+                questions = [
+                    str(q).strip()
+                    for q in raw
+                    if isinstance(q, str) and 0 < len(str(q).strip()) < 300
+                ]
+        if not questions:
+            logger.warning(
+                "synth.llm_empty_questions parsed_keys={k}",
+                k=list(parsed) if isinstance(parsed, dict) else type(parsed).__name__,
+            )
+            return []
+        # Cap at N — model occasionally emits fewer or more.
+        return questions[:QUESTIONS_PER_CHUNK]
+
+    logger.warning(
+        "synth.llm_exhausted_retries last_status={s} last_error={e}",
+        s=last_status,
+        e=last_error,
+    )
+    return []
+
+
+def _vector_literal(v: list[float]) -> str:
+    return "[" + ",".join(f"{x:.10g}" for x in v) + "]"
+
+
+async def _select_naked_chunks(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    namespace: str,
+) -> list[_ChunkRow]:
+    """Find content chunks that have no synthetic-question children.
+
+    Bounded by tenant_id (RLS-redundant but keeps the predicate explicit
+    per Principle IV) AND namespace prefix (so a `--namespace chatwoot`
+    run never touches `wiki:*` chunks).
+    """
+    rows = (
+        (
+            await session.execute(
+                text(
+                    "SELECT c.id, c.title, c.section, c.content, c.kb_entry_id "
+                    "FROM kb_chunks c "
+                    "JOIN kb_entries e ON e.id = c.kb_entry_id "
+                    "WHERE c.tenant_id = :t "
+                    "  AND c.is_synthetic_question = FALSE "
+                    "  AND e.kb_entry_key LIKE :prefix "
+                    "  AND NOT EXISTS ("
+                    "    SELECT 1 FROM kb_chunks sq "
+                    "    WHERE sq.parent_chunk_id = c.id"
+                    "  ) "
+                    "ORDER BY c.id"
+                ),
+                {"t": str(tenant_id), "prefix": f"{namespace}:%"},
+            )
+        )
+        .mappings()
+        .all()
+    )
+    return [
+        _ChunkRow(
+            id=row["id"],
+            title=row["title"],
+            section=row["section"],
+            content=row["content"],
+            kb_entry_id=row["kb_entry_id"],
+        )
+        for row in rows
+    ]
+
+
+async def run(
+    *,
+    tenant_slug: str,
+    namespace: str,
+    encode_fn: Any | None = None,
+    http_client: httpx.AsyncClient | None = None,
+) -> dict[str, Any]:
+    """Run the synthetic-question phase for one tenant + namespace.
+
+    Returns ``{added, deleted, rewriter_calls, chunks_touched, elapsed_ms}``.
+
+    ``deleted`` is always 0 in the current implementation — the cascade
+    DELETE on parent replacement happens during the content phase, not
+    here. The field is kept for forward-compatibility with a future
+    "force-regenerate" mode.
+    """
+    from config import get_settings
+    from db import get_session, set_tenant_scope
+
+    settings = get_settings()
+    started = time.perf_counter()
+
+    summary: dict[str, Any] = {
+        "added": 0,
+        "deleted": 0,
+        "rewriter_calls": 0,
+        "chunks_touched": 0,
+        "elapsed_ms": 0,
+    }
+
+    if encode_fn is None:
+        from embedder import encode, preload
+
+        await asyncio.to_thread(preload)
+        encode_fn = encode
+
+    own_client = http_client is None
+    client = http_client or httpx.AsyncClient(
+        timeout=httpx.Timeout(LLM_TIMEOUT_S, connect=2.0),
+    )
+    try:
+        async with get_session() as session:
+            # Resolve tenant inline rather than reusing tenants.resolve_tenant
+            # (which takes a UUID, not a slug). Keeps the synth phase callable
+            # standalone from the CLI without an extra lookup.
+            row = (
+                await session.execute(
+                    text("SELECT id FROM tenants WHERE slug = :slug AND status = 'active'"),
+                    {"slug": tenant_slug},
+                )
+            ).first()
+            if row is None:
+                logger.error("synth.unknown_tenant slug={s}", s=tenant_slug)
+                return summary
+            tenant_id: UUID = row[0]
+
+            await set_tenant_scope(session, tenant_id)
+            naked = await _select_naked_chunks(session, tenant_id=tenant_id, namespace=namespace)
+            logger.info(
+                "synth.start tenant={t} namespace={ns} chunks_naked={n}",
+                t=tenant_slug,
+                ns=namespace,
+                n=len(naked),
+            )
+
+            consecutive_failures = 0
+            for chunk in naked:
+                summary["chunks_touched"] += 1
+                summary["rewriter_calls"] += 1
+                questions = await _call_llm(
+                    client,
+                    base_url=str(settings.llm_base_url),
+                    api_key=settings.llm_api_key,
+                    model=settings.rewriter_model,
+                    title=chunk.title,
+                    section=chunk.section,
+                    content=chunk.content,
+                )
+                if not questions:
+                    consecutive_failures += 1
+                    # If 5 consecutive chunks fail, abort the phase —
+                    # likely the LLM is down or quota is exhausted, no
+                    # value in burning more attempts. Operator gets a
+                    # partial-success summary; next run resumes.
+                    if consecutive_failures >= 5:
+                        logger.error(
+                            "synth.aborted_after_consecutive_failures remaining={r}",
+                            r=len(naked) - summary["chunks_touched"],
+                        )
+                        break
+                    continue
+
+                consecutive_failures = 0
+                # Embed each question; insert as is_synthetic_question=TRUE
+                # with parent_chunk_id pointing at this content chunk.
+                for question in questions:
+                    embedding = await encode_fn(question)
+                    await session.execute(
+                        text(
+                            "INSERT INTO kb_chunks "
+                            "  (tenant_id, kb_entry_id, section, title, "
+                            "   content, content_sha256, embedding, "
+                            "   is_synthetic_question, parent_chunk_id) "
+                            "VALUES (:t, :eid, :section, :title, :content, "
+                            "        :sha, CAST(:emb AS vector), TRUE, :pid)"
+                        ),
+                        {
+                            "t": str(tenant_id),
+                            "eid": str(chunk.kb_entry_id),
+                            "section": chunk.section,
+                            "title": chunk.title,
+                            "content": question,
+                            "sha": _q_sha(question),
+                            "emb": _vector_literal(embedding),
+                            "pid": chunk.id,
+                        },
+                    )
+                    summary["added"] += 1
+    finally:
+        if own_client:
+            await client.aclose()
+
+    summary["elapsed_ms"] = int((time.perf_counter() - started) * 1000)
+    return summary
+
+
+def _q_sha(question: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(question.encode("utf-8")).hexdigest()

--- a/services/retriever/tests/conftest.py
+++ b/services/retriever/tests/conftest.py
@@ -14,6 +14,7 @@ all reuse it to avoid spinning up multiple containers.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import secrets
 import subprocess
@@ -197,8 +198,6 @@ def stub_vector_for(text_input: str) -> list[float]:
     behaves sensibly in tests; identical inputs always produce the same
     vector so rerun assertions hold.
     """
-    import hashlib
-
     digest = hashlib.sha256(text_input.encode("utf-8")).digest()
     # Vectors are NOT unit-normalised — pgvector's hnsw with cosine_ops
     # handles any magnitude, and the determinism contract is what tests

--- a/services/retriever/tests/conftest.py
+++ b/services/retriever/tests/conftest.py
@@ -177,6 +177,48 @@ def _vector_literal(v: list[float]) -> str:
     return "[" + ",".join(f"{x:.10g}" for x in v) + "]"
 
 
+# ─── Stub embedder helpers (shared by ingest + synth tests) ─────────────────
+#
+# Both test_ingest.py and test_synthetic_questions.py need to inject a
+# deterministic embedder that doesn't pay BGE-M3's load cost. The
+# determinism is the contract — same input → same vector across runs and
+# across test files — so it lives here as a single source of truth.
+#
+# Exposed as plain helpers (NOT pytest fixtures) because callers pass
+# the function reference into ``encode_fn`` parameters directly; a
+# fixture would mean wrapping every call site in an extra indirection
+# without buying anything.
+
+
+def stub_vector_for(text_input: str) -> list[float]:
+    """Deterministic 1024-dim stub embedding seeded by the input text.
+
+    Different inputs produce different vectors so cosine ranking still
+    behaves sensibly in tests; identical inputs always produce the same
+    vector so rerun assertions hold.
+    """
+    import hashlib
+
+    digest = hashlib.sha256(text_input.encode("utf-8")).digest()
+    # Vectors are NOT unit-normalised — pgvector's hnsw with cosine_ops
+    # handles any magnitude, and the determinism contract is what tests
+    # actually depend on.
+    raw = [b / 255.0 for b in digest]
+    while len(raw) < 1024:
+        raw.extend(b / 255.0 for b in digest)
+    return raw[:1024]
+
+
+async def stub_encode(text_input: str) -> list[float]:
+    """Async wrapper around ``stub_vector_for``.
+
+    Matches the signature of ``embedder.encode`` so the ``encode_fn``
+    injection seam in ``ingest.run`` / ``synthetic_questions.run`` can
+    take this directly.
+    """
+    return stub_vector_for(text_input)
+
+
 @pytest_asyncio.fixture
 async def retriever_app(pgvector_postgres, monkeypatch) -> AsyncIterator[dict[str, Any]]:
     """Build a fresh FastAPI app pointed at the session-scoped pgvector

--- a/services/retriever/tests/test_chunker.py
+++ b/services/retriever/tests/test_chunker.py
@@ -1,0 +1,172 @@
+"""Tests for the markdown-aware KB chunker.
+
+Pure-Python tests — no Postgres, no embedder — so they run fast and
+gate every commit. The chunker is deterministic given input; assertions
+target the structural contract (one chunk per H2/H3, overflow handling,
+image stripping, headingless fallback) rather than exact byte counts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chunker import (
+    MAX_CHARS,
+    MIN_CHARS,
+    Chunk,
+    chunk_article,
+)
+
+
+def _content(*paragraphs: str) -> str:
+    return "\n\n".join(paragraphs)
+
+
+def test_no_headings_returns_single_chunk_with_none_section() -> None:
+    body = _content(
+        "Это короткая статья без подзаголовков.",
+        "Второй абзац с дополнительной информацией.",
+    )
+    chunks = chunk_article(title="Тест", content=body)
+    assert len(chunks) == 1
+    assert chunks[0].section is None
+    assert "короткая статья" in chunks[0].content
+
+
+def test_h2_split_emits_one_chunk_per_section() -> None:
+    body = (
+        "## Раздел один\n\n"
+        "Первый раздел про получение прав.\n\n"
+        "## Раздел два\n\n"
+        "Второй раздел про цены.\n"
+    )
+    chunks = chunk_article(title="Тест", content=body)
+    sections = [c.section for c in chunks]
+    assert sections == ["Раздел один", "Раздел два"]
+    assert "получение прав" in chunks[0].content
+    assert "цены" in chunks[1].content
+
+
+def test_h3_section_path_includes_parent_h2() -> None:
+    body = (
+        "## Линия наград\n\n"
+        "Введение в линию наград.\n\n"
+        "### Аксессуары\n\n"
+        "Подробности про аксессуары.\n"
+    )
+    chunks = chunk_article(title="Тест", content=body)
+    sections = [c.section for c in chunks]
+    assert sections == ["Линия наград", "Линия наград > Аксессуары"]
+
+
+def test_orphan_h3_without_parent_h2_uses_h3_alone() -> None:
+    body = "### Первый подраздел\n\nТекст подраздела.\n"
+    chunks = chunk_article(title="Тест", content=body)
+    assert chunks[0].section == "Первый подраздел"
+
+
+def test_preamble_before_first_heading_is_emitted_with_none_section() -> None:
+    body = (
+        "Введение перед первым подзаголовком статьи.\n\n"
+        "## Раздел\n\n"
+        "Содержимое самого раздела статьи.\n"
+    )
+    chunks = chunk_article(title="Тест", content=body)
+    sections = [c.section for c in chunks]
+    # Preamble with section=None first, then the H2 section. has_headings
+    # is true so the H2 section keeps its name.
+    assert sections == [None, "Раздел"]
+
+
+def test_long_section_splits_with_part_suffix() -> None:
+    long_para = "Очень длинный абзац. " * (MAX_CHARS // 20 + 50)
+    body = f"## Большой раздел\n\n{long_para}\n"
+    chunks = chunk_article(title="Тест", content=body)
+    assert len(chunks) >= 2, "expected overflow split into multiple chunks"
+    # First chunk keeps the bare section name; subsequent chunks carry a
+    # part suffix to satisfy the (tenant, entry, section) unique key.
+    assert chunks[0].section == "Большой раздел"
+    for c in chunks[1:]:
+        assert c.section is not None and c.section.startswith("Большой раздел #")
+    for c in chunks:
+        assert len(c.content) <= MAX_CHARS + 1, "chunks must respect MAX_CHARS cap"
+
+
+def test_very_long_paragraph_falls_back_to_char_slicing() -> None:
+    # No paragraph breaks at all — chunker must character-slice.
+    huge = "слово " * (MAX_CHARS * 2 // 6)
+    body = f"## Стена текста\n\n{huge}\n"
+    chunks = chunk_article(title="Тест", content=body)
+    assert len(chunks) >= 2
+    for c in chunks:
+        assert len(c.content) <= MAX_CHARS + 1
+
+
+def test_image_with_alt_text_replaced_with_placeholder() -> None:
+    body = (
+        "## Скриншот\n\n"
+        "![Линия наград](https://chatwoot.example/blob/abc123)\n\n"
+        "Описание скриншота.\n"
+    )
+    chunks = chunk_article(title="Тест", content=body)
+    text = "\n".join(c.content for c in chunks)
+    assert "[image: Линия наград]" in text
+    assert "blob/abc123" not in text, "raw blob URL must be stripped"
+
+
+def test_image_with_empty_alt_is_dropped() -> None:
+    body = "## Картинка\n\n![](https://chatwoot.example/blob/empty)\n\nТекст после картинки.\n"
+    chunks = chunk_article(title="Тест", content=body)
+    text = "\n".join(c.content for c in chunks)
+    assert "blob/empty" not in text
+    assert "Текст после" in text
+
+
+def test_empty_content_returns_no_chunks() -> None:
+    assert chunk_article(title="Пустая", content="") == []
+    assert chunk_article(title="Пустая", content="   \n  \n") == []
+
+
+def test_headingless_overflow_uses_synthetic_section_keys() -> None:
+    long_text = ("Длинный абзац без подзаголовков. " * (MAX_CHARS // 30 + 40)).strip()
+    chunks = chunk_article(title="Без заголовков", content=long_text)
+    assert len(chunks) >= 2
+    # First chunk has section=None; subsequent overflow chunks get
+    # synthetic "#N" labels so the (tenant, entry, section) unique key
+    # still discriminates them.
+    assert chunks[0].section is None
+    for c in chunks[1:]:
+        assert c.section is not None and c.section.startswith("#")
+
+
+def test_empty_section_body_is_dropped() -> None:
+    body = "## Только заголовок\n\n## Реальный раздел\n\nРеальное содержимое.\n"
+    chunks = chunk_article(title="Тест", content=body)
+    sections = [c.section for c in chunks]
+    assert sections == ["Реальный раздел"]
+
+
+def test_short_section_below_min_chars_is_kept_when_only_chunk() -> None:
+    # Tiny content — chunker must still emit at least one chunk so the
+    # operator dashboard sees the article rather than silently skipping
+    # it. The "drop below MIN_CHARS" filter is best-effort and yields
+    # to the no-empty-output invariant.
+    tiny = "## H\n\nкр.\n"
+    chunks = chunk_article(title="Тест", content=tiny)
+    assert len(chunks) == 1
+    assert chunks[0].content
+
+
+def test_returned_objects_are_chunk_instances() -> None:
+    body = "## A\n\nБ.\n\n## B\n\nГ.\n"
+    chunks = chunk_article(title="T", content=body)
+    assert all(isinstance(c, Chunk) for c in chunks)
+    # Frozen dataclass — mutation must fail.
+    with pytest.raises(Exception):  # noqa: BLE001 — FrozenInstanceError
+        chunks[0].section = "x"  # type: ignore[misc]
+
+
+def test_min_chars_constant_is_below_max() -> None:
+    # Sanity check on the tunables — guards against an accidental edit
+    # that would make MIN >= MAX and produce zero-chunk output forever.
+    assert 0 < MIN_CHARS < MAX_CHARS

--- a/services/retriever/tests/test_chunker.py
+++ b/services/retriever/tests/test_chunker.py
@@ -170,3 +170,27 @@ def test_min_chars_constant_is_below_max() -> None:
     # Sanity check on the tunables — guards against an accidental edit
     # that would make MIN >= MAX and produce zero-chunk output forever.
     assert 0 < MIN_CHARS < MAX_CHARS
+
+
+def test_paragraph_overlap_does_not_exceed_max_chars() -> None:
+    """Regression for an overflow path in `_split_long`. Earlier code
+    seeded the next chunk with `tail (≤OVERLAP_CHARS) + "\\n\\n" + para`,
+    where `para` could be up to MAX_CHARS-1. The combined size could
+    reach OVERLAP_CHARS + 2 + (MAX_CHARS - 1) chars, busting the cap.
+
+    Reproduces the bound violation by sequencing paragraphs of size
+    ~800/1400/100 chars: first flush emits 800-char chunk, leaves an
+    overlap tail; second paragraph (~1400) joined with the tail would
+    produce ~1550 chars, exceeding MAX_CHARS=1500. After the fix, the
+    overlap is dropped when it would push past the cap.
+    """
+    para_a = "а" * 800  # short of MAX_CHARS — will pack into chunk 1
+    para_b = "б" * 1400  # large enough that overlap+para overflows
+    para_c = "в" * 100  # tail content
+    body = f"## Раздел\n\n{para_a}\n\n{para_b}\n\n{para_c}\n"
+    chunks = chunk_article(title="Тест", content=body)
+    assert len(chunks) >= 2
+    for c in chunks:
+        assert len(c.content) <= MAX_CHARS, (
+            f"chunk exceeds MAX_CHARS={MAX_CHARS}: {len(c.content)} chars"
+        )

--- a/services/retriever/tests/test_ingest.py
+++ b/services/retriever/tests/test_ingest.py
@@ -22,7 +22,6 @@ public API, until the synth phase lands).
 
 from __future__ import annotations
 
-import hashlib
 import json
 import sys
 import uuid
@@ -35,26 +34,7 @@ import pytest_asyncio
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
-
-def _vector_for(text_input: str) -> list[float]:
-    """Deterministic 1024-dim stub embedding seeded by the input text.
-
-    Different inputs produce different vectors so cosine ranking still
-    behaves sensibly in tests; identical inputs always produce the same
-    vector so rerun assertions hold.
-    """
-    digest = hashlib.sha256(text_input.encode("utf-8")).digest()
-    # Normalised to ~unit length — pgvector's hnsw index uses cosine
-    # distance, and unnormalised vectors of wildly different magnitudes
-    # produce confusing similarity scores in debug logs.
-    raw = [b / 255.0 for b in digest]
-    while len(raw) < 1024:
-        raw.extend(b / 255.0 for b in digest)
-    return raw[:1024]
-
-
-async def _stub_encode(text_input: str) -> list[float]:
-    return _vector_for(text_input)
+from tests.conftest import stub_encode as _stub_encode
 
 
 @pytest_asyncio.fixture

--- a/services/retriever/tests/test_ingest.py
+++ b/services/retriever/tests/test_ingest.py
@@ -1,0 +1,518 @@
+"""Tests for the KB ingestion CLI — content phase.
+
+Hits the session-scoped pgvector testcontainer (real Postgres, real RLS)
+but stubs the embedder so we don't pay the BGE-M3 load cost. Each test
+provisions its own tenant slug so concurrent / sequential runs don't
+collide on the unique constraint.
+
+Coverage targets:
+
+* Idempotency — re-running the same source produces zero writes.
+* Add / update / delete plumbing — diff math + side effects.
+* Mass-deletion safeguard — fires when delete-rate exceeds threshold.
+* Source validation — bad JSON files and missing namespace prefix.
+* ``--dry-run`` — no DB writes happen.
+* Empty source dir — graceful no-op rather than catastrophic delete.
+
+Synthetic-question generation is exercised by ``test_synthetic_questions.py``;
+this file only verifies that the content phase wires up the
+``skip_synthetic_questions`` toggle correctly (default = skip in the
+public API, until the synth phase lands).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+def _vector_for(text_input: str) -> list[float]:
+    """Deterministic 1024-dim stub embedding seeded by the input text.
+
+    Different inputs produce different vectors so cosine ranking still
+    behaves sensibly in tests; identical inputs always produce the same
+    vector so rerun assertions hold.
+    """
+    digest = hashlib.sha256(text_input.encode("utf-8")).digest()
+    # Normalised to ~unit length — pgvector's hnsw index uses cosine
+    # distance, and unnormalised vectors of wildly different magnitudes
+    # produce confusing similarity scores in debug logs.
+    raw = [b / 255.0 for b in digest]
+    while len(raw) < 1024:
+        raw.extend(b / 255.0 for b in digest)
+    return raw[:1024]
+
+
+async def _stub_encode(text_input: str) -> list[float]:
+    return _vector_for(text_input)
+
+
+@pytest_asyncio.fixture
+async def ingest_env(pgvector_postgres, monkeypatch) -> AsyncIterator[dict[str, Any]]:
+    """Set up retriever env + a fresh tenant for an ingestion test.
+
+    Yields a dict with ``tenant_slug`` and ``tenant_id``; the seeded
+    tenant survives the test (we don't roll back) so on-disk DB state
+    can be inspected directly. Each test gets a unique slug so we can
+    reuse the session-scoped container without collisions.
+    """
+    dsn = pgvector_postgres.get_connection_url().replace("+psycopg2", "+asyncpg")
+    monkeypatch.setenv("DB_URL", dsn)
+    monkeypatch.setenv("LLM_BASE_URL", "http://llm-test.local")
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    monkeypatch.setenv("REWRITER_MODEL", "test-rewriter-model")
+    monkeypatch.setenv("EMBEDDER_DEVICE", "cpu")
+    monkeypatch.setenv("RETRIEVER_INTERNAL_TOKEN", "test-internal-token")
+
+    import config
+    import db
+
+    config.get_settings.cache_clear()
+    db.get_engine.cache_clear()
+    db._session_factory.cache_clear()
+
+    # Provision a fresh tenant for this test.
+    tenant_id = uuid.uuid4()
+    tenant_slug = f"ingest-{tenant_id.hex[:8]}"
+    seed_engine = create_async_engine(dsn)
+    async with seed_engine.begin() as conn:
+        await conn.execute(
+            text("INSERT INTO tenants (id, name, slug, status) VALUES (:i, :n, :s, 'active')"),
+            {"i": tenant_id, "n": "Ingest Test Tenant", "s": tenant_slug},
+        )
+    await seed_engine.dispose()
+
+    # Drop cached ingest module so it picks up the new env on import.
+    sys.modules.pop("ingest", None)
+
+    yield {"tenant_slug": tenant_slug, "tenant_id": tenant_id, "dsn": dsn}
+
+    # Best-effort cleanup so test logs / re-runs don't accumulate dead
+    # tenants in a long-lived testcontainer (which is session-scoped).
+    cleanup_engine = create_async_engine(dsn)
+    async with cleanup_engine.begin() as conn:
+        await conn.execute(text("DELETE FROM tenants WHERE id = :i"), {"i": tenant_id})
+    await cleanup_engine.dispose()
+    db.get_engine.cache_clear()
+    db._session_factory.cache_clear()
+
+
+def _write_articles(tmp_path: Path, articles: list[dict[str, Any]]) -> Path:
+    """Write a list of canonical articles into a fresh kb dir under tmp."""
+    out = tmp_path / "kb"
+    out.mkdir(parents=True, exist_ok=True)
+    for art in articles:
+        # Use the suffix after the namespace prefix as the filename
+        # (mirrors fetch_chatwoot_kb.py).
+        suffix = art["kb_entry_key"].split(":", 1)[1]
+        (out / f"{suffix}.json").write_text(
+            json.dumps(art, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+    return out
+
+
+def _article(
+    kb_entry_key: str,
+    *,
+    title: str = "Тестовая статья",
+    content: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "kb_entry_key": kb_entry_key,
+        "title": title,
+        "content": content
+        if content is not None
+        else (
+            "## Раздел один\n\nПервое содержательное содержимое статьи.\n\n"
+            "## Раздел два\n\nВторое содержательное содержимое статьи.\n"
+        ),
+        "source_uri": f"https://example.test/{kb_entry_key}",
+        "metadata": metadata or {"source": "chatwoot"},
+    }
+
+
+async def _count(dsn: str, sql: str, params: dict[str, Any]) -> int:
+    engine = create_async_engine(dsn)
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(text(sql), params)
+            return int(result.scalar_one())
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.slow
+async def test_ingest_adds_new_entries(ingest_env, tmp_path) -> None:
+    import ingest
+
+    src = _write_articles(
+        tmp_path,
+        [
+            _article("chatwoot:1"),
+            _article("chatwoot:2", title="Вторая"),
+        ],
+    )
+
+    summary = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"],
+        source=src,
+        encode_fn=_stub_encode,
+    )
+
+    assert summary["entries"]["seen"] == 2
+    assert summary["entries"]["added"] == 2
+    assert summary["entries"]["updated"] == 0
+    assert summary["entries"]["unchanged"] == 0
+    assert summary["entries"]["deleted"] == 0
+    assert summary["chunks"]["added"] >= 2  # at least one chunk per article
+    assert summary["embed_calls"] == summary["chunks"]["added"]
+    assert summary["chunks"]["deleted"] == 0
+    assert summary["namespace"] == "chatwoot"
+
+    # Verify DB state.
+    n_entries = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_entries WHERE tenant_id = :t",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_entries == 2
+
+    n_chunks = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_chunks WHERE tenant_id = :t",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_chunks == summary["chunks"]["added"]
+
+
+@pytest.mark.slow
+async def test_ingest_is_idempotent_on_unchanged_content(ingest_env, tmp_path) -> None:
+    """Second run with identical source must produce zero writes."""
+    import ingest
+
+    src = _write_articles(tmp_path, [_article("chatwoot:1"), _article("chatwoot:2")])
+
+    first = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"], source=src, encode_fn=_stub_encode
+    )
+    assert first["entries"]["added"] == 2
+
+    second = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"], source=src, encode_fn=_stub_encode
+    )
+    assert second["entries"]["added"] == 0
+    assert second["entries"]["updated"] == 0
+    assert second["entries"]["unchanged"] == 2
+    assert second["entries"]["deleted"] == 0
+    assert second["embed_calls"] == 0
+
+
+@pytest.mark.slow
+async def test_ingest_updates_changed_content(ingest_env, tmp_path) -> None:
+    import ingest
+
+    src = _write_articles(tmp_path, [_article("chatwoot:1")])
+    await ingest.run(tenant_slug=ingest_env["tenant_slug"], source=src, encode_fn=_stub_encode)
+
+    # Rewrite content for the same kb_entry_key.
+    src2 = _write_articles(
+        tmp_path / "v2",
+        [
+            _article(
+                "chatwoot:1", content="## Новый раздел\n\nСовершенно другое содержимое статьи.\n"
+            )
+        ],
+    )
+    summary = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"], source=src2, encode_fn=_stub_encode
+    )
+
+    assert summary["entries"]["added"] == 0
+    assert summary["entries"]["updated"] == 1
+    assert summary["entries"]["unchanged"] == 0
+
+    # Old chunks are gone, new chunks present.
+    n_chunks = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_chunks WHERE tenant_id = :t",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_chunks == summary["chunks"]["added"]
+
+
+@pytest.mark.slow
+async def test_ingest_deletes_entries_missing_from_source(ingest_env, tmp_path) -> None:
+    import ingest
+
+    # Seed with three; second run drops one.
+    full_src = _write_articles(tmp_path, [_article(f"chatwoot:{i}") for i in (1, 2, 3)])
+    await ingest.run(tenant_slug=ingest_env["tenant_slug"], source=full_src, encode_fn=_stub_encode)
+
+    smaller_src = _write_articles(tmp_path / "smaller", [_article(f"chatwoot:{i}") for i in (1, 2)])
+    summary = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"],
+        source=smaller_src,
+        encode_fn=_stub_encode,
+    )
+
+    # 1 of 3 deleted = 33%, but base is below MASS_DELETION_FLOOR (4),
+    # so the safeguard does NOT fire.
+    assert summary["entries"]["deleted"] == 1
+    assert summary["chunks"]["deleted"] >= 1
+
+    n_entries = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_entries WHERE tenant_id = :t",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_entries == 2
+
+
+@pytest.mark.slow
+async def test_mass_deletion_safeguard_fires(ingest_env, tmp_path) -> None:
+    import ingest
+
+    # Seed with 10 entries.
+    full_src = _write_articles(tmp_path, [_article(f"chatwoot:{i}") for i in range(10)])
+    await ingest.run(tenant_slug=ingest_env["tenant_slug"], source=full_src, encode_fn=_stub_encode)
+
+    # New source has only 3 — would delete 7 of 10 = 70% > 25%. Safeguard
+    # fires (SystemExit with EXIT_PARTIAL_SUCCESS).
+    tiny_src = _write_articles(tmp_path / "tiny", [_article(f"chatwoot:{i}") for i in range(3)])
+    with pytest.raises(SystemExit) as exc:
+        await ingest.run(
+            tenant_slug=ingest_env["tenant_slug"],
+            source=tiny_src,
+            encode_fn=_stub_encode,
+        )
+    assert exc.value.code == ingest.EXIT_PARTIAL_SUCCESS
+
+    # DB unchanged — safeguard fires before any writes happen.
+    n_entries = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_entries WHERE tenant_id = :t",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_entries == 10
+
+
+@pytest.mark.slow
+async def test_mass_deletion_override_works(ingest_env, tmp_path) -> None:
+    import ingest
+
+    full_src = _write_articles(tmp_path, [_article(f"chatwoot:{i}") for i in range(10)])
+    await ingest.run(tenant_slug=ingest_env["tenant_slug"], source=full_src, encode_fn=_stub_encode)
+
+    tiny_src = _write_articles(tmp_path / "tiny", [_article(f"chatwoot:{i}") for i in range(3)])
+    summary = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"],
+        source=tiny_src,
+        encode_fn=_stub_encode,
+        allow_mass_deletion=True,
+    )
+    assert summary["entries"]["deleted"] == 7
+
+    n_entries = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_entries WHERE tenant_id = :t",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_entries == 3
+
+
+@pytest.mark.slow
+async def test_dry_run_writes_nothing(ingest_env, tmp_path) -> None:
+    import ingest
+
+    src = _write_articles(tmp_path, [_article("chatwoot:1"), _article("chatwoot:2")])
+    summary = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"],
+        source=src,
+        dry_run=True,
+        encode_fn=_stub_encode,
+    )
+
+    assert summary["dry_run"] is True
+    assert summary["entries"]["added"] == 2
+    assert summary["embed_calls"] == 0
+    assert summary["chunks"]["added"] == 0  # nothing actually written
+
+    n_entries = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_entries WHERE tenant_id = :t",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_entries == 0
+
+
+@pytest.mark.slow
+async def test_empty_source_dir_is_noop_not_catastrophe(ingest_env, tmp_path) -> None:
+    """Empty fetch dir must not cascade-delete the existing KB.
+
+    This is the "Chatwoot returned 0 articles because auth flipped"
+    scenario. The mass-deletion safeguard would catch it indirectly,
+    but we treat 'no source entries at all' as a hard short-circuit so
+    operators see a clear log line instead of a vague safeguard exit.
+    """
+    import ingest
+
+    # Pre-seed the tenant.
+    src = _write_articles(tmp_path, [_article("chatwoot:1"), _article("chatwoot:2")])
+    await ingest.run(tenant_slug=ingest_env["tenant_slug"], source=src, encode_fn=_stub_encode)
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    summary = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"], source=empty, encode_fn=_stub_encode
+    )
+
+    assert summary["entries"]["seen"] == 0
+    assert summary["entries"]["deleted"] == 0  # no diff was performed
+
+    # Existing entries still there.
+    n_entries = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_entries WHERE tenant_id = :t",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_entries == 2
+
+
+@pytest.mark.slow
+async def test_unknown_tenant_exits_with_bad_args(ingest_env, tmp_path) -> None:
+    import ingest
+
+    src = _write_articles(tmp_path, [_article("chatwoot:1")])
+    with pytest.raises(SystemExit) as exc:
+        await ingest.run(
+            tenant_slug="no-such-tenant-9999",
+            source=src,
+            encode_fn=_stub_encode,
+        )
+    assert exc.value.code == ingest.EXIT_BAD_ARGS
+
+
+@pytest.mark.slow
+async def test_full_mode_re_embeds_unchanged_entries(ingest_env, tmp_path) -> None:
+    """``--mode full`` forces re-embed even when content_sha256 matches."""
+    import ingest
+
+    src = _write_articles(tmp_path, [_article("chatwoot:1")])
+    first = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"], source=src, encode_fn=_stub_encode
+    )
+    assert first["entries"]["added"] == 1
+
+    second = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"],
+        source=src,
+        mode="full",
+        encode_fn=_stub_encode,
+    )
+    # Existing entry treated as updated in full mode.
+    assert second["entries"]["updated"] == 1
+    assert second["entries"]["unchanged"] == 0
+    assert second["embed_calls"] >= 1
+
+
+def test_mixed_namespaces_in_source_aborts(tmp_path) -> None:
+    """Two namespaces in one source dir triggers EXIT_PARSE_ERROR."""
+    import ingest
+
+    out = tmp_path / "kb"
+    out.mkdir()
+    (out / "a.json").write_text(
+        json.dumps(_article("chatwoot:1"), ensure_ascii=False), encoding="utf-8"
+    )
+    (out / "b.json").write_text(
+        json.dumps(_article("wiki:2"), ensure_ascii=False), encoding="utf-8"
+    )
+
+    import asyncio as _asyncio
+
+    with pytest.raises(SystemExit) as exc:
+        _asyncio.run(
+            ingest.run(
+                tenant_slug="anything",  # never reached
+                source=out,
+                encode_fn=_stub_encode,
+            )
+        )
+    assert exc.value.code == ingest.EXIT_PARSE_ERROR
+
+
+def test_load_source_dir_reports_parse_errors(tmp_path) -> None:
+    """Bad JSON / missing fields land in the errors list, not raised."""
+    import ingest
+
+    out = tmp_path / "kb"
+    out.mkdir()
+    (out / "good.json").write_text(
+        json.dumps(_article("chatwoot:1"), ensure_ascii=False), encoding="utf-8"
+    )
+    (out / "bad.json").write_text("{this is not json", encoding="utf-8")
+    (out / "missing-namespace.json").write_text(
+        json.dumps({"kb_entry_key": "nosep", "title": "x", "content": "y"}),
+        encoding="utf-8",
+    )
+
+    entries, errors = ingest._load_source_dir(out)
+    assert len(entries) == 1
+    assert entries[0].kb_entry_key == "chatwoot:1"
+    assert len(errors) == 2  # bad.json + missing-namespace.json
+
+
+def test_diff_categorises_correctly() -> None:
+    import ingest
+
+    db = {
+        "chatwoot:keep": {"content_sha256": "AAA"},
+        "chatwoot:change": {"content_sha256": "OLD"},
+        "chatwoot:gone": {"content_sha256": "ZZZ"},
+    }
+    src = [
+        ingest.SourceEntry(
+            kb_entry_key="chatwoot:keep",
+            title="t",
+            content="c",
+            content_sha256="AAA",
+            source_uri=None,
+            metadata={},
+            namespace="chatwoot",
+        ),
+        ingest.SourceEntry(
+            kb_entry_key="chatwoot:change",
+            title="t",
+            content="c2",
+            content_sha256="NEW",
+            source_uri=None,
+            metadata={},
+            namespace="chatwoot",
+        ),
+        ingest.SourceEntry(
+            kb_entry_key="chatwoot:new",
+            title="t",
+            content="c3",
+            content_sha256="BBB",
+            source_uri=None,
+            metadata={},
+            namespace="chatwoot",
+        ),
+    ]
+
+    plan = ingest._diff(src, db, "chatwoot")
+    assert [e.kb_entry_key for e in plan.add] == ["chatwoot:new"]
+    assert [e.kb_entry_key for e in plan.update] == ["chatwoot:change"]
+    assert [e.kb_entry_key for e in plan.unchanged] == ["chatwoot:keep"]
+    assert plan.delete == ["chatwoot:gone"]

--- a/services/retriever/tests/test_ingest.py
+++ b/services/retriever/tests/test_ingest.py
@@ -496,3 +496,185 @@ def test_diff_categorises_correctly() -> None:
     assert [e.kb_entry_key for e in plan.update] == ["chatwoot:change"]
     assert [e.kb_entry_key for e in plan.unchanged] == ["chatwoot:keep"]
     assert plan.delete == ["chatwoot:gone"]
+
+
+# ─── Review-feedback regression tests (PR #64 ce-code-review fixes) ─────────
+
+
+def test_namespace_with_like_wildcard_rejected_at_parse_time(tmp_path) -> None:
+    """A kb_entry_key whose namespace contains ``%`` or ``_`` would
+    otherwise smuggle SQL LIKE wildcards into the diff predicate and
+    match cross-namespace entries. ``_load_source_dir`` rejects these
+    at parse time."""
+    import ingest
+
+    out = tmp_path / "kb"
+    out.mkdir()
+    (out / "evil.json").write_text(
+        json.dumps({"kb_entry_key": "%:x", "title": "t", "content": "c"}),
+        encoding="utf-8",
+    )
+    (out / "evil2.json").write_text(
+        json.dumps({"kb_entry_key": "ws ns:x", "title": "t", "content": "c"}),
+        encoding="utf-8",
+    )
+    (out / "good.json").write_text(
+        json.dumps(_article("chatwoot:1"), ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    entries, errors = ingest._load_source_dir(out)
+    assert len(entries) == 1
+    assert entries[0].kb_entry_key == "chatwoot:1"
+    assert len(errors) == 2
+    assert any("%" in e for e in errors) or any("disallowed" in e for e in errors)
+
+
+def test_nul_byte_in_content_is_stripped() -> None:
+    """``_normalise_content`` strips ``\\x00``; Postgres TEXT would
+    otherwise reject the INSERT and roll back the entire run."""
+    import ingest
+
+    raw = "before\x00after\x00\x00more"
+    normalised = ingest._normalise_content(raw)
+    assert "\x00" not in normalised
+    assert "before" in normalised
+    assert "after" in normalised
+    assert "more" in normalised
+
+
+@pytest.mark.slow
+async def test_empty_source_with_only_parse_errors_short_circuits(ingest_env, tmp_path) -> None:
+    """All-files-fail-parse must NOT fall through to the diff. The
+    earlier guard required ``not source_entries and not parse_errors``;
+    a parse-only failure would slip past it, namespace would be ``""``,
+    and ``LIKE "%"`` would queue every existing entry for deletion.
+    Tiny KBs (≤4 entries) would lose them all silently because the
+    mass-deletion floor wouldn't fire."""
+    import ingest
+
+    # Pre-seed two entries.
+    src = _write_articles(tmp_path, [_article("chatwoot:1"), _article("chatwoot:2")])
+    await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"],
+        source=src,
+        encode_fn=_stub_encode,
+    )
+
+    # New source with nothing but invalid files.
+    bad_dir = tmp_path / "bad-kb"
+    bad_dir.mkdir()
+    (bad_dir / "broken.json").write_text("{this is not json", encoding="utf-8")
+    (bad_dir / "missing.json").write_text(
+        json.dumps({"kb_entry_key": "nosep", "title": "x", "content": "y"}),
+        encoding="utf-8",
+    )
+
+    summary = await ingest.run(
+        tenant_slug=ingest_env["tenant_slug"],
+        source=bad_dir,
+        encode_fn=_stub_encode,
+    )
+    assert summary["entries"]["seen"] == 0
+    assert summary["entries"]["deleted"] == 0
+    assert len(summary["parse_errors"]) == 2
+
+    # Existing entries untouched.
+    n_entries = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_entries WHERE tenant_id = :t",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_entries == 2
+
+
+@pytest.mark.slow
+async def test_mass_deletion_safeguard_fires_at_floor_boundary(ingest_env, tmp_path) -> None:
+    """A 5-entry KB with 4 deletes (80%) used to slip past the floor
+    because the safeguard checked ``> MASS_DELETION_FLOOR`` (4 not
+    being strictly greater than 4). After the fix, ``>= 4`` triggers
+    it."""
+    import ingest
+
+    # Seed 5.
+    full = _write_articles(tmp_path, [_article(f"chatwoot:{i}") for i in range(5)])
+    await ingest.run(tenant_slug=ingest_env["tenant_slug"], source=full, encode_fn=_stub_encode)
+
+    # Smaller source: 1 entry. Would delete 4 of 5 (80%).
+    smaller = _write_articles(tmp_path / "smaller", [_article("chatwoot:0")])
+    with pytest.raises(SystemExit) as exc:
+        await ingest.run(
+            tenant_slug=ingest_env["tenant_slug"],
+            source=smaller,
+            encode_fn=_stub_encode,
+        )
+    assert exc.value.code == ingest.EXIT_PARTIAL_SUCCESS
+
+    # No writes happened.
+    n_entries = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_entries WHERE tenant_id = :t",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_entries == 5
+
+
+@pytest.mark.slow
+async def test_skip_synthetic_questions_false_runs_synth_phase(
+    ingest_env, tmp_path, monkeypatch
+) -> None:
+    """``skip_synthetic_questions=False`` actually runs the synth phase
+    end-to-end and propagates its summary into the ingest summary. This
+    integration seam was previously untested — every test passed
+    ``True`` or used the default."""
+    import respx
+    import ingest
+    import synthetic_questions as sq
+
+    src = _write_articles(tmp_path, [_article("chatwoot:1")])
+
+    chat_url = "http://llm-test.local/chat/completions"
+    questions = ["q1?", "q2?", "q3?", "q4?"]
+    llm_body = json.dumps({"questions": questions}, ensure_ascii=False)
+
+    # Patch synth to use the same stub embedder as ingest. The LLM
+    # transport is its own AsyncClient inside synth.run, so respx
+    # matches by URL regardless of which client made the call.
+    real_synth_run = sq.run
+
+    async def stubbed_synth_run(*, tenant_slug, namespace, encode_fn=None, http_client=None):
+        return await real_synth_run(
+            tenant_slug=tenant_slug,
+            namespace=namespace,
+            encode_fn=_stub_encode,
+            http_client=http_client,
+        )
+
+    monkeypatch.setattr(sq, "run", stubbed_synth_run)
+
+    with respx.mock(assert_all_called=False) as mock:
+        mock.post(chat_url).respond(
+            200,
+            json={"choices": [{"message": {"content": llm_body}}]},
+        )
+
+        summary = await ingest.run(
+            tenant_slug=ingest_env["tenant_slug"],
+            source=src,
+            encode_fn=_stub_encode,
+            skip_synthetic_questions=False,
+        )
+
+    # Content phase landed at least one chunk, synth phase generated
+    # questions for it.
+    assert summary["entries"]["added"] == 1
+    assert summary["chunks"]["added"] >= 1
+    assert summary["synthetic_questions"]["added"] >= 4
+    assert summary["rewriter_calls"] >= 1
+
+    n_synth = await _count(
+        ingest_env["dsn"],
+        "SELECT count(*) FROM kb_chunks WHERE tenant_id = :t   AND is_synthetic_question = TRUE",
+        {"t": ingest_env["tenant_id"]},
+    )
+    assert n_synth >= 4

--- a/services/retriever/tests/test_synthetic_questions.py
+++ b/services/retriever/tests/test_synthetic_questions.py
@@ -23,17 +23,7 @@ import respx
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
-
-def _vector_for(s: str) -> list[float]:
-    digest = hashlib.sha256(s.encode("utf-8")).digest()
-    raw = [b / 255.0 for b in digest]
-    while len(raw) < 1024:
-        raw.extend(b / 255.0 for b in digest)
-    return raw[:1024]
-
-
-async def _stub_encode(s: str) -> list[float]:
-    return _vector_for(s)
+from tests.conftest import stub_encode as _stub_encode
 
 
 @pytest_asyncio.fixture

--- a/services/retriever/tests/test_synthetic_questions.py
+++ b/services/retriever/tests/test_synthetic_questions.py
@@ -1,0 +1,390 @@
+"""Tests for the synthetic-question generation phase.
+
+Stubs the LLM via ``respx`` so we don't hit Groq during CI. Hits the
+session-scoped pgvector testcontainer so the SQL (parent_chunk_id FK,
+is_synthetic_question filter, NOT EXISTS naked-chunk query) actually
+runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+def _vector_for(s: str) -> list[float]:
+    digest = hashlib.sha256(s.encode("utf-8")).digest()
+    raw = [b / 255.0 for b in digest]
+    while len(raw) < 1024:
+        raw.extend(b / 255.0 for b in digest)
+    return raw[:1024]
+
+
+async def _stub_encode(s: str) -> list[float]:
+    return _vector_for(s)
+
+
+@pytest_asyncio.fixture
+async def synth_env(pgvector_postgres, monkeypatch) -> AsyncIterator[dict[str, Any]]:
+    """Spin up a fresh tenant + ingest some content so synth has work."""
+    dsn = pgvector_postgres.get_connection_url().replace("+psycopg2", "+asyncpg")
+    monkeypatch.setenv("DB_URL", dsn)
+    monkeypatch.setenv("LLM_BASE_URL", "http://llm-test.local")
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    monkeypatch.setenv("REWRITER_MODEL", "test-model")
+    monkeypatch.setenv("EMBEDDER_DEVICE", "cpu")
+    monkeypatch.setenv("RETRIEVER_INTERNAL_TOKEN", "test-internal-token")
+
+    import config
+    import db
+
+    config.get_settings.cache_clear()
+    db.get_engine.cache_clear()
+    db._session_factory.cache_clear()
+
+    tenant_id = uuid.uuid4()
+    tenant_slug = f"synth-{tenant_id.hex[:8]}"
+    seed_engine = create_async_engine(dsn)
+    async with seed_engine.begin() as conn:
+        await conn.execute(
+            text("INSERT INTO tenants (id, name, slug, status) VALUES (:i, :n, :s, 'active')"),
+            {"i": tenant_id, "n": "Synth Test", "s": tenant_slug},
+        )
+    await seed_engine.dispose()
+
+    sys.modules.pop("ingest", None)
+    sys.modules.pop("synthetic_questions", None)
+
+    yield {"tenant_slug": tenant_slug, "tenant_id": tenant_id, "dsn": dsn}
+
+    cleanup_engine = create_async_engine(dsn)
+    async with cleanup_engine.begin() as conn:
+        await conn.execute(text("DELETE FROM tenants WHERE id = :i"), {"i": tenant_id})
+    await cleanup_engine.dispose()
+    db.get_engine.cache_clear()
+    db._session_factory.cache_clear()
+
+
+def _ingest_simple(tmp_path: Path) -> Path:
+    """Write one short article to ingest as content so synth has chunks."""
+    out = tmp_path / "kb"
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "1.json").write_text(
+        json.dumps(
+            {
+                "kb_entry_key": "chatwoot:1",
+                "title": "Цены на права",
+                "content": (
+                    "## Получение прав\n\n"
+                    "Чтобы получить водительские права, посетите автошколу "
+                    "и сдайте экзамены. Стоимость обучения — 5 000 долларов.\n"
+                ),
+                "source_uri": "https://example.test/1",
+                "metadata": {"source": "chatwoot"},
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return out
+
+
+@pytest.mark.slow
+async def test_synth_inserts_questions_with_parent_chunk_id(synth_env, tmp_path) -> None:
+    """Happy path: LLM returns 4 questions; each gets inserted as
+    is_synthetic_question=True with parent_chunk_id linking to the
+    content chunk."""
+    import ingest
+    import synthetic_questions
+
+    src = _ingest_simple(tmp_path)
+    await ingest.run(
+        tenant_slug=synth_env["tenant_slug"],
+        source=src,
+        encode_fn=_stub_encode,
+        skip_synthetic_questions=True,
+    )
+
+    chat_url = "http://llm-test.local/chat/completions"
+    questions = [
+        "Сколько стоит обучение в автошколе?",
+        "Где получить водительские права?",
+        "Какие экзамены сдавать на права?",
+        "Цена за получение прав?",
+    ]
+    llm_body = json.dumps({"questions": questions}, ensure_ascii=False)
+
+    with respx.mock(assert_all_called=False) as mock:
+        mock.post(chat_url).respond(
+            200,
+            json={"choices": [{"message": {"content": llm_body}}]},
+        )
+
+        async with httpx.AsyncClient() as client:
+            summary = await synthetic_questions.run(
+                tenant_slug=synth_env["tenant_slug"],
+                namespace="chatwoot",
+                encode_fn=_stub_encode,
+                http_client=client,
+            )
+
+    assert summary["added"] == 4
+    assert summary["chunks_touched"] == 1
+    assert summary["rewriter_calls"] == 1
+
+    # DB invariants.
+    engine = create_async_engine(synth_env["dsn"])
+    try:
+        async with engine.connect() as conn:
+            n_synth = (
+                await conn.execute(
+                    text(
+                        "SELECT count(*) FROM kb_chunks "
+                        "WHERE tenant_id = :t AND is_synthetic_question = TRUE"
+                    ),
+                    {"t": synth_env["tenant_id"]},
+                )
+            ).scalar_one()
+            n_orphan = (
+                await conn.execute(
+                    text(
+                        "SELECT count(*) FROM kb_chunks "
+                        "WHERE tenant_id = :t AND is_synthetic_question = TRUE "
+                        "  AND parent_chunk_id IS NULL"
+                    ),
+                    {"t": synth_env["tenant_id"]},
+                )
+            ).scalar_one()
+            n_self_parent = (
+                await conn.execute(
+                    text(
+                        "SELECT count(*) FROM kb_chunks "
+                        "WHERE tenant_id = :t AND is_synthetic_question = TRUE "
+                        "  AND parent_chunk_id = id"
+                    ),
+                    {"t": synth_env["tenant_id"]},
+                )
+            ).scalar_one()
+    finally:
+        await engine.dispose()
+
+    assert n_synth == 4
+    assert n_orphan == 0  # invariant: every synth row has a parent
+    assert n_self_parent == 0  # parent must point at a content chunk
+
+
+@pytest.mark.slow
+async def test_synth_is_idempotent_on_rerun(synth_env, tmp_path) -> None:
+    """Second run with no new naked chunks must not call the LLM again."""
+    import ingest
+    import synthetic_questions
+
+    src = _ingest_simple(tmp_path)
+    await ingest.run(
+        tenant_slug=synth_env["tenant_slug"],
+        source=src,
+        encode_fn=_stub_encode,
+        skip_synthetic_questions=True,
+    )
+
+    chat_url = "http://llm-test.local/chat/completions"
+    llm_body = json.dumps({"questions": ["q1?", "q2?", "q3?", "q4?"]}, ensure_ascii=False)
+
+    with respx.mock(assert_all_called=False) as mock:
+        chat_route = mock.post(chat_url).respond(
+            200, json={"choices": [{"message": {"content": llm_body}}]}
+        )
+
+        async with httpx.AsyncClient() as client:
+            first = await synthetic_questions.run(
+                tenant_slug=synth_env["tenant_slug"],
+                namespace="chatwoot",
+                encode_fn=_stub_encode,
+                http_client=client,
+            )
+            assert first["added"] == 4
+            calls_after_first = chat_route.call_count
+
+            second = await synthetic_questions.run(
+                tenant_slug=synth_env["tenant_slug"],
+                namespace="chatwoot",
+                encode_fn=_stub_encode,
+                http_client=client,
+            )
+
+    # Second run sees no naked chunks → zero LLM calls + zero new rows.
+    assert second["added"] == 0
+    assert second["chunks_touched"] == 0
+    assert chat_route.call_count == calls_after_first
+
+
+@pytest.mark.slow
+async def test_synth_aborts_after_consecutive_429s(synth_env, tmp_path) -> None:
+    """Persistent rate-limit responses → phase aborts gracefully, leaving
+    content chunks intact and naked for the next run."""
+    import ingest
+    import synthetic_questions
+
+    # Ingest 8 short articles → 8 content chunks, all naked.
+    out = tmp_path / "kb"
+    out.mkdir(parents=True, exist_ok=True)
+    for i in range(8):
+        (out / f"{i}.json").write_text(
+            json.dumps(
+                {
+                    "kb_entry_key": f"chatwoot:{i}",
+                    "title": f"Статья {i}",
+                    "content": f"## Раздел\n\nСодержательное содержимое статьи номер {i}.\n",
+                    "source_uri": None,
+                    "metadata": {},
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+    await ingest.run(
+        tenant_slug=synth_env["tenant_slug"],
+        source=out,
+        encode_fn=_stub_encode,
+        skip_synthetic_questions=True,
+    )
+
+    chat_url = "http://llm-test.local/chat/completions"
+    with respx.mock(assert_all_called=False) as mock:
+        mock.post(chat_url).respond(429, json={"error": "rate_limited"})
+
+        async with httpx.AsyncClient() as client:
+            # Patch sleep so the test doesn't actually wait between
+            # backoffs (3 attempts × 0.5s + 1s + 2s = ~3.5s/chunk = 28s
+            # total without this patch).
+            import asyncio as _asyncio
+
+            real_sleep = _asyncio.sleep
+
+            async def fast_sleep(_seconds: float) -> None:
+                await real_sleep(0)
+
+            mp = pytest.MonkeyPatch()
+            try:
+                mp.setattr(synthetic_questions.asyncio, "sleep", fast_sleep)
+                summary = await synthetic_questions.run(
+                    tenant_slug=synth_env["tenant_slug"],
+                    namespace="chatwoot",
+                    encode_fn=_stub_encode,
+                    http_client=client,
+                )
+            finally:
+                mp.undo()
+
+    # Phase aborted after 5 consecutive failures (5 chunks touched, 0
+    # added). Remaining chunks stay naked for the next run.
+    assert summary["added"] == 0
+    assert summary["chunks_touched"] >= 5
+    assert summary["chunks_touched"] <= 8
+
+
+@pytest.mark.slow
+async def test_synth_skips_chunks_with_existing_children(synth_env, tmp_path) -> None:
+    """A pre-existing synthetic-question row protects its parent from
+    re-synthesis even on the first synth run."""
+    import ingest
+    import synthetic_questions
+
+    src = _ingest_simple(tmp_path)
+    await ingest.run(
+        tenant_slug=synth_env["tenant_slug"],
+        source=src,
+        encode_fn=_stub_encode,
+        skip_synthetic_questions=True,
+    )
+
+    # Manually insert a synth row pointing at the existing content chunk
+    # so the NOT EXISTS filter excludes it.
+    engine = create_async_engine(synth_env["dsn"])
+    async with engine.begin() as conn:
+        await conn.execute(
+            text("SELECT set_config('app.current_tenant_id', :t, true)"),
+            {"t": str(synth_env["tenant_id"])},
+        )
+        chunk_row = (
+            (
+                await conn.execute(
+                    text(
+                        "SELECT id, kb_entry_id, title, section "
+                        "FROM kb_chunks WHERE tenant_id = :t "
+                        "  AND is_synthetic_question = FALSE LIMIT 1"
+                    ),
+                    {"t": synth_env["tenant_id"]},
+                )
+            )
+            .mappings()
+            .first()
+        )
+        assert chunk_row is not None
+        sha = hashlib.sha256(b"manual-q").hexdigest()
+        emb = "[" + ",".join("0.1" for _ in range(1024)) + "]"
+        await conn.execute(
+            text(
+                "INSERT INTO kb_chunks "
+                "  (tenant_id, kb_entry_id, section, title, content, "
+                "   content_sha256, embedding, is_synthetic_question, "
+                "   parent_chunk_id) "
+                "VALUES (:t, :e, :s, :ti, 'manual?', :sha, "
+                "        CAST(:emb AS vector), TRUE, :pid)"
+            ),
+            {
+                "t": synth_env["tenant_id"],
+                "e": chunk_row["kb_entry_id"],
+                "s": chunk_row["section"],
+                "ti": chunk_row["title"],
+                "sha": sha,
+                "emb": emb,
+                "pid": chunk_row["id"],
+            },
+        )
+    await engine.dispose()
+
+    chat_url = "http://llm-test.local/chat/completions"
+    with respx.mock(assert_all_called=False) as mock:
+        chat_route = mock.post(chat_url).respond(
+            200,
+            json={"choices": [{"message": {"content": '{"questions": ["?"]}'}}]},
+        )
+        async with httpx.AsyncClient() as client:
+            summary = await synthetic_questions.run(
+                tenant_slug=synth_env["tenant_slug"],
+                namespace="chatwoot",
+                encode_fn=_stub_encode,
+                http_client=client,
+            )
+
+    assert summary["chunks_touched"] == 0
+    assert chat_route.call_count == 0
+
+
+@pytest.mark.slow
+async def test_synth_unknown_tenant_returns_empty_summary(synth_env) -> None:
+    """Unknown slug = no-op, never raises."""
+    import synthetic_questions
+
+    async with httpx.AsyncClient() as client:
+        summary = await synthetic_questions.run(
+            tenant_slug="nope-9999",
+            namespace="chatwoot",
+            encode_fn=_stub_encode,
+            http_client=client,
+        )
+    assert summary["added"] == 0
+    assert summary["chunks_touched"] == 0

--- a/specs/002-helper-guide-npc/contracts/ingest.cli.md
+++ b/specs/002-helper-guide-npc/contracts/ingest.cli.md
@@ -11,14 +11,17 @@ job on the retriever host.
 ## Synopsis
 
 ```
-python -m retriever.ingest \
+python -m ingest \
   --tenant <tenant-slug> \
-  --source <path-or-url> \
+  --source <path> \
   [--mode {full,incremental}] \
   [--dry-run] \
+  [--allow-mass-deletion] \
   [--skip-synthetic-questions] \
   [--verbose]
 ```
+
+Run from `services/retriever/` (locally) or `docker compose exec retriever uv run python -m ingest ...` (production). The flat-layout retriever package means the canonical invocation is `python -m ingest`, NOT `python -m retriever.ingest` — the latter would require a parent package this service does not have.
 
 ---
 
@@ -26,12 +29,33 @@ python -m retriever.ingest \
 
 | Arg                         | Required | Default        | Notes |
 |-----------------------------|----------|----------------|-------|
-| `--tenant <slug>`           | yes      | —              | Must match `tenants.slug`. The CLI rejects unknown slugs. |
-| `--source <path-or-url>`    | yes      | —              | Path to a directory of Markdown/JSON/YAML files, or a URL returning the same. Tenant-specific; format convention documented per tenant. |
+| `--tenant <slug>`           | yes      | —              | Must match `tenants.slug`. The CLI rejects unknown or non-active slugs with exit 64. |
+| `--source <path>`           | yes      | —              | Path to a directory of `*.json` files in the canonical KB-entry shape (see below). Tenant-source mapping is operator policy; the CLI is source-agnostic. |
 | `--mode {full,incremental}` | no       | `incremental`  | `incremental`: upsert by content hash (skip re-embed on unchanged chunks). `full`: force re-embed every chunk. |
-| `--dry-run`                 | no       | false          | Print the plan (chunks to add / update / delete) without writing to the DB or calling the embedder. |
-| `--skip-synthetic-questions`| no       | false          | Skip the synthetic-question-generation LLM pass. Used when the eval harness is measuring content-only recall (R11 gate). |
-| `--verbose`                 | no       | false          | Emit per-chunk decisions (added / updated / skipped / deleted) as structured loguru output. |
+| `--dry-run`                 | no       | false          | Print the plan (entries to add / update / delete) without writing to the DB or calling the embedder. |
+| `--allow-mass-deletion`     | no       | false          | Override the >25% delete-rate safeguard. Only set when the operator deliberately intends to prune ≥25% of existing entries (e.g., bulk Chatwoot cleanup). The safeguard fires above `MASS_DELETION_FLOOR=4` deletions; a 5-entry KB with 4 deletes triggers it. |
+| `--skip-synthetic-questions`| no       | false          | Skip the synthetic-question-generation LLM pass. Used when the eval harness is measuring content-only recall (R11 gate). Default behavior runs synthesis as a separate phase after the content commit. |
+| `--verbose`                 | no       | false          | Emit per-entry decisions (added / updated / unchanged / deleted) as structured loguru output on stderr. Stdout still carries only the JSON summary. |
+
+---
+
+## Source format
+
+Each `*.json` file under `--source` MUST conform to:
+
+```json
+{
+  "kb_entry_key": "<namespace>:<id>",
+  "title": "...",
+  "content": "...markdown...",
+  "source_uri": "https://...",       // optional
+  "metadata": { "...": "..." }       // optional, free-form, lands in kb_chunks.metadata
+}
+```
+
+The `<namespace>` segment of `kb_entry_key` MUST match `[A-Za-z0-9.-]+` (no SQL LIKE wildcards or whitespace). A single source directory MUST contain entries from exactly one namespace; mixed namespaces exit with code 65. The fetcher (`tools/fetch_chatwoot_kb.py`) writes entries with `kb_entry_key="chatwoot:<id>"`.
+
+`_manifest.json` in the source directory is reserved for fetcher metadata and skipped by ingest.
 
 ---
 
@@ -49,42 +73,74 @@ python -m retriever.ingest \
 
 ## Output (on stdout, structured)
 
-On success, one JSON line to stdout:
+On success, exactly one JSON line is written to stdout. The shape groups
+related counts so consumers can iterate over per-phase counters cleanly:
 
 ```json
 {
   "tenant": "<slug>",
+  "source": "/abs/path/to/source-dir",
+  "namespace": "chatwoot",
   "mode": "incremental",
-  "elapsed_ms": 12834,
-  "entries_seen": 42,
-  "chunks_added": 7,
-  "chunks_updated": 3,
-  "chunks_unchanged": 117,
-  "chunks_deleted": 2,
-  "synthetic_questions_added": 28,
-  "synthetic_questions_deleted": 8,
-  "embed_calls": 10,
-  "rewriter_calls": 7
+  "dry_run": false,
+  "entries": {
+    "seen": 71,
+    "added": 2,
+    "updated": 3,
+    "unchanged": 65,
+    "deleted": 1
+  },
+  "chunks": {
+    "added": 17,
+    "deleted": 8,
+    "unchanged": 462
+  },
+  "embed_calls": 17,
+  "synthetic_questions": {
+    "added": 68,
+    "deleted": 0
+  },
+  "rewriter_calls": 17,
+  "parse_errors": [],
+  "elapsed_ms": 42100
 }
 ```
 
-On `--dry-run`, same shape but no writes occurred. On exit codes 65/74/75,
-additionally write a second JSON line naming affected entries.
+`parse_errors` is an array of human-readable strings naming each source
+file that failed validation, in the form `"<filename>: <reason>"`. An
+empty array means every `*.json` parsed cleanly; non-empty + exit code
+75 (partial success) means the run committed valid entries while
+recording the failures. Consumers that want to alert on parse drift
+should branch on `len(parse_errors) > 0` rather than expecting a
+separate JSON document.
+
+`synthetic_questions.deleted` is always `0` in the current
+implementation — synthetic-question rows cascade-delete with their
+parent on content replacement (the content phase handles it before the
+synth phase runs). The field is reserved for a future explicit
+"force-regenerate" mode.
+
+On `--dry-run`, the same shape is emitted; `entries` reflects the
+diff plan and `chunks.added` / `chunks.deleted` are zero (no writes
+happened). `chunks.unchanged` is populated from the DB so the operator
+can see the baseline.
 
 ---
 
 ## Idempotency guarantees
 
-- Running with unchanged source → `chunks_added = 0`, `chunks_updated = 0`,
-  `embed_calls = 0`. Enforced by content-hash skip (SC-009).
+- Running with unchanged source → `entries.added = entries.updated = 0`,
+  `entries.unchanged = entries.seen`, `chunks.added = embed_calls = 0`.
+  Enforced by content-hash skip (SC-009).
 - Content-hash computation: `SHA-256(normalize(content))` where `normalize`
-  strips trailing whitespace and normalizes newlines. Any richer normalization
-  (punctuation, diacritics) is NOT applied — it would make "trivial" edits
-  invisible and cause staleness.
-- Upsert keys: `(tenant_id, kb_entry_id, section, is_synthetic_question=false)`
-  for content chunks. Synthetic questions are DELETE + INSERT together with
-  their parent on parent-content change; their key is
-  `(tenant_id, parent_chunk_id, sequence)`.
+  strips NUL bytes (Postgres TEXT rejects them), normalizes Windows line
+  endings to Unix, and strips trailing whitespace per line. Any richer
+  normalization (punctuation, diacritics, image stripping) is NOT applied —
+  it would make "trivial" edits invisible and cause staleness.
+- Upsert keys: `(tenant_id, kb_entry_id, section)` with `NULLS NOT DISTINCT`
+  for content chunks (see migration 0004). Synthetic questions are DELETE
+  + INSERT together with their parent on parent-content change via
+  `parent_chunk_id ON DELETE CASCADE`; their key is the BIGSERIAL `id`.
 
 ---
 
@@ -100,17 +156,33 @@ Advisory lock key: `hash_int8('kb_ingest:' || tenant_id::text)`.
 
 ## Failure modes
 
-- **Embedder OOM / missing CUDA**: exit 74, nothing committed.
-- **Postgres connection lost mid-run**: exit 74, the current transaction
-  rolls back; previous transactions (if any) remain. Operator re-runs
-  `--mode incremental` — idempotent.
-- **Rewriter LLM rate-limited**: the metadata-extraction pass retries with
-  exponential backoff up to 3 attempts per entry; after that, the entry's
-  metadata stays empty but the chunk is still committed (retrieval still
-  works, just without structured metadata). Exit code 75 if any entry hit
-  this.
-- **Source parse error on one entry**: skip the entry, log the key, continue;
-  exit code 75.
+- **Embedder OOM / missing CUDA / model-load error**: exit 74, nothing
+  committed. Caught at `main()` boundary.
+- **Postgres connection lost mid-run / SQLAlchemy error**: exit 74, the
+  current transaction rolls back. Operator re-runs `--mode incremental`
+  — idempotent.
+- **Rewriter LLM rate-limited (synth phase only)**: per-chunk retries
+  with exponential backoff up to 3 attempts. Beyond that, the chunk is
+  skipped and remains naked for the next run (the NOT EXISTS filter
+  picks it up). After 5 consecutive chunk failures the synth phase
+  aborts to avoid burning quota; content is unaffected.
+- **Synth-phase per-chunk DB error**: each chunk's question batch runs
+  in its own transaction so a FK violation (concurrent ingest deleted
+  the parent) or transient asyncpg error rolls back only that chunk's
+  questions; the chunk stays naked for the next run.
+- **Source parse error on one entry**: skip the entry, append to
+  `parse_errors`, continue. Exit code 75 if any entry hit this.
+- **Empty source dir or all entries failed parse**: short-circuit with
+  exit 75 and `parse_errors` populated. The CLI explicitly does NOT
+  fall through to the diff in this case — empty source would otherwise
+  match every existing entry for the (now-empty) namespace and queue
+  them all for deletion.
+- **Mass-deletion safeguard**: when `len(plan.delete) >= 4` AND
+  `len(plan.delete) / len(db_entries) > 0.25`, exit 75 without writes
+  unless `--allow-mass-deletion` is passed.
+- **NUL bytes in source content**: stripped during normalization with a
+  loguru warning (`ingest.nul_bytes_stripped`). Postgres TEXT rejects
+  NUL; silently failing would wedge the entire run on rollback.
 
 ---
 

--- a/tools/fetch_chatwoot_kb.py
+++ b/tools/fetch_chatwoot_kb.py
@@ -41,7 +41,11 @@ Exit codes
 
 The script intentionally uses only the stdlib so it can run on any
 Python 3.10+ host without a venv (e.g. on the VM directly when running
-the fetch out-of-band).
+the fetch out-of-band). This is a deliberate exception to the project's
+loguru-everywhere convention (CLAUDE.md): loguru is a third-party
+dependency and would break the stdlib-only constraint. The
+``logging.getLogger`` calls below use stdlib ``%``-style lazy
+formatting, which is the equivalent discipline for the stdlib logger.
 """
 
 from __future__ import annotations
@@ -204,12 +208,23 @@ def fetch(config: FetchConfig) -> dict[str, Any]:
 
     written: list[str] = []
     seen_ids: list[str] = []
+    seen_set: set[str] = set()  # dedup so duplicate upstream IDs don't
+    # inflate manifest count.
     for article in articles:
         if "id" not in article:
             log.warning("skipping article without id: %r", article.get("title"))
             continue
-        normalised = _normalise(article, config.project, config.base_url, fetched_at)
         safe = _safe_id(str(article["id"]))
+        if safe in seen_set:
+            # Duplicate id from upstream — the second copy would
+            # overwrite the first via tmp+rename, leaving exactly one
+            # file on disk. Reflect that on the manifest by NOT
+            # double-counting; warn so the operator can chase the
+            # upstream data-quality issue.
+            log.warning("duplicate article id from upstream: %r", safe)
+            continue
+        seen_set.add(safe)
+        normalised = _normalise(article, config.project, config.base_url, fetched_at)
         seen_ids.append(safe)
         target = config.out_dir / f"{safe}.json"
         if config.dry_run:

--- a/tools/fetch_chatwoot_kb.py
+++ b/tools/fetch_chatwoot_kb.py
@@ -1,0 +1,304 @@
+"""Fetch the Chatwoot help-base feed and write per-article JSON files.
+
+Usage::
+
+    CHATWOOT_HELP_BASE_TOKEN=<bearer> \\
+        uv run python tools/fetch_chatwoot_kb.py --project arizona
+
+Output layout::
+
+    data/kb/<project>/
+        <id>.json          # one per article (normalised shape)
+        _manifest.json     # {fetched_at, count, ids, project, base_url}
+
+Each article file contains the canonical shape consumed by the (still
+to-be-implemented) ``services/retriever/ingest.py`` CLI:
+
+    {
+      "kb_entry_key": "chatwoot:<id>",
+      "title": "...",
+      "content": "...markdown...",
+      "source_uri": "https://chatwoot.arizona-rp.com/api-help-base/get?project=<p>&id=<id>",
+      "metadata": {
+        "category_name": "...",
+        "portal_name":   "...",
+        "description":   null,
+        "source":        "chatwoot",
+        "fetched_at":    "<rfc3339>"
+      }
+    }
+
+The Chatwoot endpoint returns the entire feed in one response (no
+pagination today), so this is a single-request fetch. Writes are
+atomic (``.tmp`` + ``rename``) so a partial run never leaves a
+half-written file in the working tree.
+
+Exit codes
+----------
+* ``0`` — fetched and wrote the feed (or dry-run completed).
+* ``1`` — auth/network/parse error. No partial writes committed.
+* ``64`` — bad CLI args (missing project, bad out-dir, etc.).
+
+The script intentionally uses only the stdlib so it can run on any
+Python 3.10+ host without a venv (e.g. on the VM directly when running
+the fetch out-of-band).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+# stderr-bound logger so the stdout summary line stays a single,
+# machine-parseable JSON document.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stderr,
+)
+log = logging.getLogger("fetch_chatwoot_kb")
+
+DEFAULT_BASE_URL = "https://chatwoot.arizona-rp.com"
+DEFAULT_OUT_ROOT = "data/kb"
+HTTP_TIMEOUT_S = 30.0
+# Article ids are treated as strings on input; sanitise anything outside
+# this safelist before using one as a filename. Real ids today are
+# integer-valued strings ("116"), but the API contract does not
+# guarantee that.
+_SAFE_ID_RE = re.compile(r"[^a-zA-Z0-9._-]")
+
+
+@dataclass(frozen=True)
+class FetchConfig:
+    project: str
+    out_dir: Path
+    base_url: str
+    token: str
+    dry_run: bool
+
+
+def _safe_id(raw: str) -> str:
+    """Make an article id safe for use as a filename component.
+
+    Replaces every char outside ``[A-Za-z0-9._-]`` with ``_``.
+    Also rejects the empty string, ``.``, and ``..`` to avoid any
+    chance of writing outside ``out_dir``.
+    """
+
+    cleaned = _SAFE_ID_RE.sub("_", raw)
+    if cleaned in {"", ".", ".."}:
+        raise ValueError(f"unsafe article id: {raw!r}")
+    return cleaned
+
+
+def _http_get_json(url: str, token: str) -> dict[str, Any]:
+    """GET ``url`` with the bearer token, parse JSON, return the body.
+
+    Uses the verbatim header form documented by the Chatwoot endpoint
+    (``authorization: <token>``, no ``Bearer`` prefix).
+    """
+
+    req = urllib.request.Request(  # noqa: S310 — explicit https URL
+        url,
+        method="GET",
+        headers={
+            "authorization": token,
+            "accept": "application/json",
+            "user-agent": "project-800ms-fetch-chatwoot-kb/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:  # noqa: S310
+            raw = resp.read()
+    except urllib.error.HTTPError as err:
+        # Surface response body to ease debugging (auth/quota messages
+        # land here). Do not echo the request token.
+        body = err.read().decode("utf-8", errors="replace") if err.fp else ""
+        raise SystemExit(f"HTTP {err.code} from {url}: {body[:500]}") from None
+    except urllib.error.URLError as err:
+        raise SystemExit(f"network error fetching {url}: {err.reason}") from None
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as err:
+        raise SystemExit(f"non-JSON response from {url}: {err}") from None
+
+
+def _normalise(
+    article: dict[str, Any], project: str, base_url: str, fetched_at: str
+) -> dict[str, Any]:
+    """Project a Chatwoot article into the canonical KB-entry shape.
+
+    Drops every field not listed in ``metadata`` so changes upstream
+    (new fields) don't silently flow into the ingestion pipeline
+    without review.
+    """
+
+    raw_id = str(article["id"])
+    safe = _safe_id(raw_id)
+    source_uri = f"{base_url.rstrip('/')}/api-help-base/get?" + urlencode(
+        {"project": project, "id": raw_id}
+    )
+    return {
+        "kb_entry_key": f"chatwoot:{safe}",
+        "title": article.get("title") or "",
+        "content": article.get("content") or "",
+        "source_uri": source_uri,
+        "metadata": {
+            "category_name": article.get("category_name"),
+            "portal_name": article.get("portal_name"),
+            "description": article.get("description"),
+            "source": "chatwoot",
+            "fetched_at": fetched_at,
+            "raw_id": raw_id,
+        },
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` to ``path`` via a tmp-rename so partial writes
+    never leave a half-baked file behind.
+    """
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+def fetch(config: FetchConfig) -> dict[str, Any]:
+    """Fetch the feed and write it to disk. Returns the summary dict.
+
+    Raises ``SystemExit`` on any unrecoverable error.
+    """
+
+    started = time.perf_counter()
+    feed_url = f"{config.base_url.rstrip('/')}/api-help-base/get?" + urlencode(
+        {"project": config.project}
+    )
+    log.info("fetching feed url=%s", feed_url)
+    body = _http_get_json(feed_url, config.token)
+
+    if not body.get("success"):
+        raise SystemExit(f"feed reported success=false: {body}")
+    articles = body.get("data") or []
+    if not isinstance(articles, list):
+        raise SystemExit(f"expected data: list, got {type(articles).__name__}")
+
+    fetched_at = dt.datetime.now(dt.UTC).isoformat(timespec="seconds")
+    config.out_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[str] = []
+    seen_ids: list[str] = []
+    for article in articles:
+        if "id" not in article:
+            log.warning("skipping article without id: %r", article.get("title"))
+            continue
+        normalised = _normalise(article, config.project, config.base_url, fetched_at)
+        safe = _safe_id(str(article["id"]))
+        seen_ids.append(safe)
+        target = config.out_dir / f"{safe}.json"
+        if config.dry_run:
+            log.info(
+                "[dry-run] would write %s (%d bytes content)",
+                target,
+                len(normalised["content"]),
+            )
+        else:
+            _atomic_write_json(target, normalised)
+            written.append(str(target))
+
+    manifest = {
+        "project": config.project,
+        "base_url": config.base_url,
+        "fetched_at": fetched_at,
+        "count": len(seen_ids),
+        "ids": sorted(seen_ids),
+    }
+    if not config.dry_run:
+        _atomic_write_json(config.out_dir / "_manifest.json", manifest)
+
+    elapsed_ms = int((time.perf_counter() - started) * 1000)
+    summary = {
+        "project": config.project,
+        "out_dir": str(config.out_dir),
+        "fetched": len(seen_ids),
+        "written": len(written),
+        "dry_run": config.dry_run,
+        "elapsed_ms": elapsed_ms,
+    }
+    return summary
+
+
+def _build_config(args: argparse.Namespace) -> FetchConfig:
+    token = os.environ.get("CHATWOOT_HELP_BASE_TOKEN", "").strip()
+    if not token:
+        raise SystemExit(
+            "CHATWOOT_HELP_BASE_TOKEN is empty — set it in the environment "
+            "(local: source infra/.env; VM: it is written by the startup "
+            "script when chatwoot_help_base_token is set in terraform.tfvars)."
+        )
+    project = args.project.strip()
+    if not project or "/" in project:
+        # exit code 64: bad CLI args (matches the ingest CLI contract).
+        log.error("invalid --project value: %r", args.project)
+        raise SystemExit(64)
+    out_dir = Path(args.out_dir) if args.out_dir else Path(DEFAULT_OUT_ROOT) / project
+    return FetchConfig(
+        project=project,
+        out_dir=out_dir,
+        base_url=args.base_url,
+        token=token,
+        dry_run=args.dry_run,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch Chatwoot help-base articles and write per-article JSON files.",
+    )
+    parser.add_argument(
+        "--project",
+        default="arizona",
+        help="Chatwoot project slug (default: arizona).",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help="Destination directory (default: data/kb/<project>/).",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help=f"Chatwoot base URL (default: {DEFAULT_BASE_URL}).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch and report counts, but do not write any files.",
+    )
+    args = parser.parse_args(argv)
+
+    config = _build_config(args)
+    summary = fetch(config)
+    # Single-line JSON summary on stdout (parseable by ops tooling).
+    print(json.dumps(summary, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

End-to-end pipeline for getting external KB content into the retriever's `kb_entries` / `kb_chunks` tables. First source: Chatwoot help-base. Designed to be re-run on a daily cron — idempotent on content hash, with a mass-deletion safeguard so an upstream auth flip can't silently nuke the KB.

After this lands the demo-tenant UI can answer Russian questions grounded in the 71 Chatwoot articles. Pipeline is multi-source-ready (namespace prefix in `kb_entry_key`); a future Wiki / Notion fetcher slots in without touching this code.

- 🧱 **chunker**: markdown-aware (H2/H3 split, H1 strip, image strip, MAX_CHARS=1500 with overlap)
- 🧮 **ingest CLI**: `python -m ingest --tenant demo --source /app/data/kb/arizona/ --mode incremental` — pg_advisory_xact_lock, content-hash idempotency, prefix-scoped diff, mass-deletion safeguard, `--dry-run`
- 🤖 **synthetic questions**: separate phase; 4 paraphrased Russian Qs per chunk via rewriter LLM; resumable on retry (queries chunks with no synth children); aborts after 5 consecutive LLM failures so a down LLM never blocks content commits
- 🌐 **fetcher**: `tools/fetch_chatwoot_kb.py` — stdlib-only, atomic writes, manifest snapshot, non-destructive on disk
- ⏰ **wrapper**: `scripts/refresh_kb.sh demo arizona` — cron-callable; refuses 0-article upstream
- 🔐 **infra**: `chatwoot_help_base_token` wired through Secret Manager → `infra/.env`; `data/` bind-mounted into retriever
- 📖 **docs**: operator runbook in `docs/solutions/best-practices/`

## Test plan

- [x] `pytest tests/test_chunker.py` — 15/15 (pure-python, fast)
- [x] `pytest tests/test_ingest.py` — 13/13 (pgvector testcontainer + stub embedder)
- [x] `pytest tests/test_synthetic_questions.py` — 5/5 (testcontainer + respx-mocked LLM)
- [x] Full retriever suite — 104/104 passing
- [x] Smoke-test chunker against live 71-article Chatwoot feed: mean 7.6 chunks/article, p50 522 chars, max 1500 chars
- [ ] After merge: terraform apply (provisions `chatwoot_help_base_token` Secret)
- [ ] After merge: VM pulls new retriever image, runs `./scripts/refresh_kb.sh demo arizona`
- [ ] After merge: smoke-test in UI — ask a Russian question grounded in a Chatwoot article

## Deploy notes

1. Merge → CI publishes new retriever image to GHCR (~10-15 min)
2. `terraform apply` to add the new Secret Manager entry (in-place metadata patch, no VM destroy — protected by recent #61 fix)
3. SSH to VM: `cd /opt/project-800ms && git pull && docker compose pull retriever && docker compose up -d --no-deps --force-recreate retriever`
4. First refresh: `./scripts/refresh_kb.sh demo arizona`
   - First run will burn ~150-200 Groq calls (one per content chunk for synth Qs); well under 1000 RPD daily quota
   - Subsequent daily runs are near-zero cost (idempotent on content hash)

## Future-update story

Daily cron on the VM:
```bash
0 4 * * * /opt/project-800ms/scripts/refresh_kb.sh demo arizona >> /var/log/project-800ms-kb-refresh.log 2>&1
```

Mass-deletion safeguard refuses to delete >25% of existing entries unless `--allow-mass-deletion` is passed. Catches the "Chatwoot auth flipped → empty feed" failure mode before it nukes the KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)