### PR TITLE
fix(retriever,tools,infra): unblock first-deploy KB ingest — three small bugs

### DIFF
--- a/scripts/refresh_kb.sh
+++ b/scripts/refresh_kb.sh
@@ -120,13 +120,17 @@ INGEST_CMD=(
     --env-file "${ENV_FILE}"
     -f "${REPO_ROOT}/infra/docker-compose.yml"
     exec -T retriever
-    uv run python -m ingest
+    python -m ingest
     --tenant "${TENANT}"
     --source "/app/data/kb/${PROJECT}/"
     --mode incremental
 )
 
 # Apply prod overlay when present — same pattern the startup script uses.
+# The retriever runtime image bakes its venv at /opt/venv and exposes
+# ``python`` directly on PATH; ``uv`` is a build-time-only dependency
+# and is NOT in the runtime image. ``python -m ingest`` (not
+# ``uv run python``) is the correct in-container invocation.
 if [[ -f "${REPO_ROOT}/infra/docker-compose.prod.yml" ]]; then
     INGEST_CMD=(
         docker compose
@@ -134,7 +138,7 @@ if [[ -f "${REPO_ROOT}/infra/docker-compose.prod.yml" ]]; then
         -f "${REPO_ROOT}/infra/docker-compose.yml"
         -f "${REPO_ROOT}/infra/docker-compose.prod.yml"
         exec -T retriever
-        uv run python -m ingest
+        python -m ingest
         --tenant "${TENANT}"
         --source "/app/data/kb/${PROJECT}/"
         --mode incremental

--- a/services/retriever/chunker.py
+++ b/services/retriever/chunker.py
@@ -282,6 +282,37 @@ def chunk_article(*, title: str, content: str) -> list[Chunk]:
     # list for an article that had any content — keep at least the
     # longest chunk as the article's representation.
     survivors = [c for c in chunks if len(c.content) >= MIN_CHARS]
-    if survivors:
-        return survivors
-    return [max(chunks, key=lambda c: len(c.content))] if chunks else []
+    if not survivors:
+        return [max(chunks, key=lambda c: len(c.content))] if chunks else []
+    return _ensure_unique_sections(survivors)
+
+
+def _ensure_unique_sections(chunks: list[Chunk]) -> list[Chunk]:
+    """Append ``" #N"`` suffixes to repeated section names so the
+    ``(tenant_id, kb_entry_id, section) NULLS NOT DISTINCT`` unique
+    index never sees collisions within a single article.
+
+    Some upstream Markdown sources (Chatwoot help-base in particular)
+    repeat boilerplate H2 headings like ``"🆘 Не нашли решения?"`` at
+    the bottom of multiple sections. The chunker preserves both
+    occurrences so retrieval still pulls the right paragraph; the
+    suffix just disambiguates the DB key. Both ``None`` and
+    string-valued sections are handled (``"#2"`` for the headingless
+    overflow case, ``"<section> #N"`` otherwise).
+    """
+    seen: set[str | None] = set()
+    out: list[Chunk] = []
+    for chunk in chunks:
+        sec = chunk.section
+        if sec in seen:
+            n = 2
+            while True:
+                candidate = f"{sec} #{n}" if sec else f"#{n}"
+                if candidate not in seen:
+                    sec = candidate
+                    break
+                n += 1
+            chunk = Chunk(sec, chunk.content)
+        seen.add(sec)
+        out.append(chunk)
+    return out

--- a/services/retriever/tests/test_chunker.py
+++ b/services/retriever/tests/test_chunker.py
@@ -194,3 +194,35 @@ def test_paragraph_overlap_does_not_exceed_max_chars() -> None:
         assert len(c.content) <= MAX_CHARS, (
             f"chunk exceeds MAX_CHARS={MAX_CHARS}: {len(c.content)} chars"
         )
+
+
+def test_repeated_section_names_get_unique_suffixes() -> None:
+    """Articles with repeated H2 (boilerplate footer-style headings,
+    common in Chatwoot help-base — e.g. ``"🆘 Не нашли решения?"``
+    appearing at the bottom of multiple sections) used to violate the
+    ``(tenant_id, kb_entry_id, section) NULLS NOT DISTINCT`` unique
+    index. Repeated sections now get ``" #2"``, ``" #3"`` suffixes
+    so each chunk has a distinct DB key.
+
+    Concrete failure: article 17 in the live Chatwoot feed has
+    ``"🆘 Не нашли решения?"`` three times; the ingest UPSERT raised
+    ``UniqueViolationError`` and rolled back the entire run.
+    """
+    body = (
+        "## Раздел A\n\nСодержимое первого раздела статьи.\n\n"
+        "## 🆘 Не нашли решения?\n\nКонтакт первый, обратитесь к нам.\n\n"
+        "## Раздел B\n\nСодержимое второго раздела статьи.\n\n"
+        "## 🆘 Не нашли решения?\n\nКонтакт второй, повторим ссылку.\n\n"
+        "## Раздел C\n\nСодержимое третьего раздела статьи.\n\n"
+        "## 🆘 Не нашли решения?\n\nКонтакт третий, последний.\n"
+    )
+    chunks = chunk_article(title="Тест", content=body)
+    sections = [c.section for c in chunks]
+    # Hard DB invariant — all section keys within an article must be
+    # distinct.
+    assert len(set(sections)) == len(sections), f"duplicate sections produced: {sections}"
+    # The first repeat keeps the bare name; subsequent ones get suffixes.
+    repeats = [s for s in sections if s and "Не нашли" in s]
+    assert repeats[0] == "🆘 Не нашли решения?"
+    assert repeats[1] == "🆘 Не нашли решения? #2"
+    assert repeats[2] == "🆘 Не нашли решения? #3"

--- a/tools/fetch_chatwoot_kb.py
+++ b/tools/fetch_chatwoot_kb.py
@@ -203,7 +203,10 @@ def fetch(config: FetchConfig) -> dict[str, Any]:
     if not isinstance(articles, list):
         raise SystemExit(f"expected data: list, got {type(articles).__name__}")
 
-    fetched_at = dt.datetime.now(dt.UTC).isoformat(timespec="seconds")
+    # ``dt.timezone.utc`` rather than ``dt.UTC`` so this script also runs
+    # on the VM's stock Python 3.10 (``dt.UTC`` was added in 3.11). The
+    # script header advertises 3.10+ compatibility — keep it honest.
+    fetched_at = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
     config.out_dir.mkdir(parents=True, exist_ok=True)
 
     written: list[str] = []


### PR DESCRIPTION
Three bugs surfaced during the post-merge deploy of PR #64. All hot-patched on the VM to unblock the first refresh; this PR makes the fixes durable.

## Bugs

1. **chunker emits duplicate section names** when an article has repeated H2 headings. Chatwoot help-base puts \`🆘 Не нашли решения?\` at the bottom of multiple sections in article 17 — three identical sections triggered \`UniqueViolationError\` on \`uq_kb_chunks_content\` and rolled back the entire run. Fix: \`_ensure_unique_sections()\` post-processor appends \` #2\`, \` #3\` to repeats.

2. **fetcher uses Python 3.11+ \`dt.UTC\`** despite the script header advertising 3.10+. VM ships 3.10 → \`AttributeError: module 'datetime' has no attribute 'UTC'\`. Fix: \`dt.timezone.utc\` (universal).

3. **refresh_kb.sh calls \`uv run python -m ingest\`** but \`uv\` is build-time only — not installed in the retriever runtime image. \`exec: \"uv\": executable file not found in \$PATH\`. Fix: invoke \`python -m ingest\` directly (venv is on PATH at \`/opt/venv\`).

## Test plan

- [x] \`pytest tests/test_chunker.py\` — 17 tests pass (1 new regression for the article-17 failure)
- [x] \`pytest tests/test_chunker.py tests/test_ingest.py tests/test_synthetic_questions.py\` — 40 tests pass
- [x] Hot-patched on the VM, first refresh now in progress (fetch ✓, ingest running)
- [ ] After merge: VM re-pulls new image, second refresh runs cleanly without hot-patches

🤖 Generated with [Claude Code](https://claude.com/claude-code)