### PR TITLE
chore(agent,retriever,web): post-PR67 review cleanup

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -19,8 +19,7 @@ const API_KEY = import.meta.env.VITE_API_KEY ?? "";
 // instead of comparing against a literal sentinel string (sed during
 // container start would substitute that sentinel too — a self-
 // collision that defeats the dev-build fallback).
-const TTS_PRELOAD_ENGINES_RAW: string | undefined = import.meta.env
-  .VITE_TTS_PRELOAD_ENGINES;
+const TTS_PRELOAD_ENGINES_RAW = import.meta.env.VITE_TTS_PRELOAD_ENGINES;
 
 interface VoiceOption {
   id: string;
@@ -112,19 +111,25 @@ type TtsEngine = (typeof TTS_ENGINES)[number]["id"];
 // whitelist is also why we can avoid a string-sentinel fallback for
 // the unsubstituted `__TTS_PRELOAD_ENGINES__` case (which sed would
 // rewrite alongside the actual value, breaking the sentinel).
-const VALID_ENGINE_IDS: ReadonlySet<string> = new Set(
-  TTS_ENGINES.map((e) => e.id),
-);
+//
+// Type inferred as `Set<TtsEngine>` so a stray `string` argument to
+// `.has()` is a compile error, not a silent boolean answer. The type
+// guard `isValidEngineId` widens the input contract to `string` for
+// the env-derived call site.
+const VALID_ENGINE_IDS = new Set(TTS_ENGINES.map((e) => e.id));
+
+const isValidEngineId = (s: string): s is TtsEngine =>
+  (VALID_ENGINE_IDS as ReadonlySet<string>).has(s);
 
 // Engines the runtime feature flag has whitelisted. Falls back to the
 // full catalog when the flag is unset / unsubstituted / contains no
 // recognized engine ids. Computed once at module load — TTS_PRELOAD_-
 // ENGINES is a deploy-time setting, not a per-render one.
-const TTS_PRELOAD_ENGINES_FILTER: ReadonlySet<string> | null = (() => {
+const TTS_PRELOAD_ENGINES_FILTER = (() => {
   if (!TTS_PRELOAD_ENGINES_RAW) return null;
   const ids = TTS_PRELOAD_ENGINES_RAW.split(",")
-    .map((s: string) => s.trim().toLowerCase())
-    .filter((s: string) => VALID_ENGINE_IDS.has(s));
+    .map((s) => s.trim().toLowerCase())
+    .filter(isValidEngineId);
   return ids.length > 0 ? new Set(ids) : null;
 })();
 
@@ -337,12 +342,6 @@ export function App() {
       <h1>project-800ms</h1>
       <p className="subtitle">Pick a TTS engine + voice to start a call.</p>
       <div className="engine-picker">
-        {VISIBLE_ENGINES.length === 0 && (
-          <div className="status error">
-            No TTS engines enabled. Set TTS_PRELOAD_ENGINES on the web service
-            (e.g. <code>piper,silero,xtts</code>).
-          </div>
-        )}
         {VISIBLE_ENGINES.map((engine) => {
           const isPending = pendingEngine === engine.id && status === "connecting";
           const voice = selectedVoice[engine.id];

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -6,6 +6,11 @@ interface ImportMetaEnv {
   // the page can read it. Use a tenant with origin + rate-limit scoped
   // tightly to the SPA's domain. Full auth flows belong on a real backend.
   readonly VITE_API_KEY?: string;
+  // Comma-separated list of TTS engines visible in the engine picker.
+  // Substituted at container start by the web one-shot — see
+  // apps/web/Dockerfile and infra/docker-compose.tls.yml. Undefined in
+  // dev (`bun run dev`) so the SPA falls back to the full catalog.
+  readonly VITE_TTS_PRELOAD_ENGINES?: string;
 }
 
 interface ImportMeta {

--- a/docs/solutions/best-practices/runtime-placeholder-substitution-self-collision-2026-05-02.md
+++ b/docs/solutions/best-practices/runtime-placeholder-substitution-self-collision-2026-05-02.md
@@ -1,0 +1,226 @@
+---
+title: "Avoid sentinel-string comparisons in runtime sed-substituted bundles"
+module: apps/web
+date: 2026-05-02
+category: docs/solutions/best-practices
+problem_type: best_practice
+component: tooling
+severity: high
+root_cause: logic_error
+resolution_type: code_fix
+applies_when:
+  - "Vite (or any bundler) build with placeholder ARG values in a Dockerfile"
+  - "Runtime sed / envsubst substitution on JS/CSS assets in a container entrypoint"
+  - "Build-time placeholder string also appears as a literal in source comparisons"
+  - "Build-once / deploy-anywhere Docker image model with deploy-time config injection"
+tags:
+  - sed
+  - runtime-substitution
+  - vite
+  - docker
+  - placeholder
+  - sentinel
+  - whitelist-validation
+  - feature-flag
+---
+
+# Avoid sentinel-string comparisons in runtime sed-substituted bundles
+
+## Context
+
+This project ships a Vite SPA via the *publish-once, deploy-anywhere* pattern: the bundle is built once with placeholder env values baked in at build time, the GHCR image is pulled to any environment, and a one-shot busybox container rewrites the placeholders in-place at deploy time using `sed`. That keeps a single image promotable through staging and production with no rebuild.
+
+```dockerfile
+# apps/web/Dockerfile (excerpt)
+ARG VITE_API_URL=__API_URL__
+ARG VITE_API_KEY=__API_KEY__
+ARG VITE_TTS_PRELOAD_ENGINES=__TTS_PRELOAD_ENGINES__
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_API_KEY=$VITE_API_KEY
+ENV VITE_TTS_PRELOAD_ENGINES=$VITE_TTS_PRELOAD_ENGINES
+RUN bun run build
+
+# ... (later, at container start)
+CMD ["/bin/sh", "-c", "set -e; \
+  : \"${TTS_PRELOAD_ENGINES:?...}\"; \
+  cp -r /dist-template/. /dist/; \
+  grep -rl __TTS_PRELOAD_ENGINES__ /dist | xargs -r sed -i \
+    \"s|__TTS_PRELOAD_ENGINES__|${TTS_PRELOAD_ENGINES}|g\"; \
+"]
+```
+
+The pattern is sound. The friction point is when application code wants to distinguish between **"substitution has not run yet"** (dev mode, or pre-sed) and **"substitution ran and produced a real value"**. The intuitive solution — compare the runtime value against the placeholder literal — is a trap, because that comparison is itself a substitution target.
+
+## Guidance
+
+**Prefer detect-by-whitelist over detect-by-sentinel for runtime-substituted code.** Validate against an authoritative domain catalog. Anything that fails validation — unsubstituted placeholder, typo, empty string — collapses to the same safe fallback behavior. There is no literal sentinel string in the source for `sed` to collide with.
+
+### Wrong — sentinel comparison
+
+```ts
+// apps/web/src/App.tsx (PR #67 — buggy)
+const TTS_PRELOAD_ENGINES_RAW =
+  import.meta.env.VITE_TTS_PRELOAD_ENGINES ?? "__TTS_PRELOAD_ENGINES__";
+
+const TTS_PRELOAD_ENGINES_FILTER: ReadonlySet<string> | null = (() => {
+  if (
+    !TTS_PRELOAD_ENGINES_RAW ||
+    TTS_PRELOAD_ENGINES_RAW === "__TTS_PRELOAD_ENGINES__"  // ← literal sentinel
+  ) {
+    return null;  // "show all engines" fallback for dev
+  }
+  // ... filter logic ...
+})();
+```
+
+Vite inlines `import.meta.env.VITE_TTS_PRELOAD_ENGINES` at build time. With `ARG VITE_TTS_PRELOAD_ENGINES=__TTS_PRELOAD_ENGINES__`, the literal `__TTS_PRELOAD_ENGINES__` ends up in **two** places in the compiled bundle:
+
+1. The variable assignment (the intended `sed` target).
+2. The string literal inside the `=== "__TTS_PRELOAD_ENGINES__"` comparison (collateral).
+
+When the container's `sed -i "s|__TTS_PRELOAD_ENGINES__|piper,silero,xtts|g"` runs at deploy time, it rewrites both occurrences. The runtime check becomes:
+
+```ts
+if (RAW === "piper,silero,xtts") return null;  // always true post-substitution
+```
+
+The filter always returns `null`. The feature flag is permanently disabled.
+
+### Right — whitelist validation
+
+```ts
+// apps/web/src/App.tsx (PR #68 — fixed)
+const TTS_PRELOAD_ENGINES_RAW = import.meta.env.VITE_TTS_PRELOAD_ENGINES;
+// undefined in dev | '__TTS_PRELOAD_ENGINES__' pre-sed | 'piper,silero,xtts' post-sed
+
+const VALID_ENGINE_IDS = new Set(TTS_ENGINES.map((e) => e.id));
+//    ^? Set<TtsEngine> — narrow union from the authoritative catalog
+
+const isValidEngineId = (s: string): s is TtsEngine =>
+  (VALID_ENGINE_IDS as ReadonlySet<string>).has(s);
+
+const TTS_PRELOAD_ENGINES_FILTER = (() => {
+  if (!TTS_PRELOAD_ENGINES_RAW) return null;
+  const ids = TTS_PRELOAD_ENGINES_RAW.split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(isValidEngineId);          // unrecognised tokens → filtered out
+  return ids.length > 0 ? new Set(ids) : null;
+})();
+```
+
+Three clean cases — none of them depend on a literal sentinel:
+
+| Situation | `RAW` value | Result |
+|---|---|---|
+| `bun run dev` (no env) | `undefined` | `null` → all engines shown |
+| Docker build, `sed` not yet run | `'__TTS_PRELOAD_ENGINES__'` | split → 0 valid ids → `null` → all engines shown (graceful) |
+| Docker build, `sed` ran with real value | `'piper,silero,xtts'` | split → 3 valid ids → `Set(3)` → filter active |
+
+No sentinel literal exists in the source. `sed` has exactly one occurrence to substitute.
+
+## Why This Matters
+
+### The bug is silent
+
+The wrong path is the *safe* path. "Show all engines" is the same fallback used in dev mode, so a manual tester who doesn't already know which engines were configured can stare at the UI and see nothing alarming. Only a tester who specifically expects an engine to be hidden will catch it.
+
+### Substitution confirms success, logic is still broken
+
+`curl`-ing the live bundle and `grep`-ing for the placeholder pattern returns zero hits — `sed` did its job. The substituted value appears in the bundle in the right place. A build engineer reading the dist sees nothing wrong. The defect is not in the substitution; it's in the relationship between two source tokens that compile down to the same byte sequence.
+
+### Debugging cost
+
+In this incident the wrong-engine-set symptom led to suspicion of: wrong env var on the host, Docker layer cache serving stale dist, Caddy serving unprocessed assets, browser cache poisoning. All were investigated before bundle source inspection finally revealed the double occurrence. *(session history)* The root cause is unintuitive because it requires reasoning simultaneously about Vite inlining, `sed` global substitution, and string-literal identity in source.
+
+### Why the original `__API_URL__` / `__API_KEY__` pattern didn't hit this
+
+The pre-existing pattern (set up when the SPA was first containerized for GHCR) was structurally safe: those placeholder strings only appeared in the env-var assignment site, never in any comparison expression elsewhere in the source. Each placeholder appeared exactly once in the bundle, so `sed` had nothing to collide with. The implicit assumption — *"each placeholder appears exactly once"* — was never explicit, and it broke as soon as someone (correctly) wanted to detect the unsubstituted state at runtime. *(session history)*
+
+## When to Apply
+
+This guidance applies whenever a source file uses the **same byte sequence** as both the substitution target and a literal operand elsewhere:
+
+- Vite / webpack / esbuild builds with `ARG`-injected placeholder env vars that `sed` rewrites at deploy time
+- `envsubst` over HTML/JS/YAML config files where template variables (`${VAR}` or `__VAR__`) double as comparison operands
+- Backend equivalents — Go/Python/Ruby config structs where a placeholder default (`"__DB_URL__"`) is compared in a startup health check; the same substitution will corrupt the check
+- Any shell, Python, or Go template where the substitution marker doubles as a magic-value sentinel in application logic
+
+The pattern generalizes: **if your substitution tool performs a global string replace** (which `sed -i`, `envsubst`, and most template engines do), **any occurrence of the target string in source — not just the intended one — will be replaced.**
+
+## Related Traps and Brittle Workarounds
+
+### Same bug class, different surface
+
+```ts
+// Still broken — sed rewrites the substring inside .includes()
+if (RAW.includes("__TTS_PRELOAD_ENGINES__")) return null;
+
+// Still broken — sed finds the full string regardless of JS expression form
+if (RAW.startsWith("__")) return null;
+// (and produces false positives for any other __VAR__ env var)
+```
+
+### Apparent workaround: split the literal at type-time
+
+```ts
+// FRAGILE — do not do this
+const SENTINEL = "__TTS_PRELOAD" + "_ENGINES__";
+if (RAW === SENTINEL) return null;
+```
+
+This appears to defeat `sed`'s pattern match because at the source level, the bytes are split. But:
+
+- Minifiers (esbuild, terser, Vite's rollup) constant-fold string concatenations of literals — the merged literal reappears in the bundle and `sed` rewrites it again.
+- TypeScript `const` inlining can do the same.
+- Behavior is implementation-defined and silently regresses on a compiler / minifier upgrade.
+- It's cargo-cult obscurantism: the next engineer who reads it won't understand why the string is split, and will "clean it up."
+
+### The correct principle
+
+Don't have a literal sentinel at all. Validate against the domain catalog. If a value is not a member of the known-good set, treat it as absent — whether it's `undefined`, an empty string, an unsubstituted placeholder, or a typo. This collapses three fragile branches (dev / pre-sed / post-sed) into one straightforward membership test with no string literals that can be contaminated.
+
+## Prevention
+
+### Code convention for runtime-substituted env reads
+
+```ts
+// VITE_TTS_PRELOAD_ENGINES is injected at build time as a placeholder
+// and rewritten by sed at deploy time. Do NOT compare against the
+// placeholder string — the comparison itself would be rewritten.
+// Validate against the domain catalog instead.
+const TTS_PRELOAD_ENGINES_RAW = import.meta.env.VITE_TTS_PRELOAD_ENGINES;
+```
+
+### Smoke-test invariant
+
+After running `sed` (or `envsubst`) in a build or smoke-test script, assert that **zero** occurrences of any placeholder pattern remain in the dist:
+
+```sh
+remaining=$(grep -rl '__[A-Z_]*__' /app/dist/assets/*.js | wc -l)
+if [ "$remaining" -gt 0 ]; then
+  echo "ERROR: unsubstituted placeholders remain in dist" >&2
+  grep -rn '__[A-Z_]*__' /app/dist/assets/*.js >&2
+  exit 1
+fi
+```
+
+This catches a different failure mode (env var unset, sed step skipped) but also catches a self-collision indirectly: if a sentinel comparison was rewritten, the bundle will still pass this check, but a *companion* assertion that the substituted value parses to a valid domain element will surface the bug. The current CI smoke test in `.github/workflows/ci.yml` only checks placeholder absence; pairing it with a runtime-behavior assertion (issue #69) would catch this class.
+
+### Test coverage
+
+The original bug shipped because the SPA's filter logic had no unit tests at all (issue #70). A small extracted pure function `buildEngineFilter(raw, validIds)` is straightforwardly testable against:
+
+- `raw === undefined` → `null`
+- `raw === "__TTS_PRELOAD_ENGINES__"` (sentinel collision pattern) → `null` (because zero ids match the whitelist)
+- `raw === "piper,silero,xtts"` → `Set(3)`
+- `raw === "qwn3,slero"` (typos) → `null`
+- `raw === "  Piper , SILERO  "` (whitespace + case) → `Set(2)` after normalization
+
+A test for the sentinel-collision case specifically prevents regression even if a future refactor reintroduces a literal-comparison check.
+
+## Related
+
+- **Companion hazard, same `sed` CMD:** issue [#71](https://github.com/gofrolist/project-800ms/issues/71) — `${TTS_PRELOAD_ENGINES}` flows unquoted into the `sed` replacement field, so `&` or `|` in the value (operator typo or supply-chain compromise) breaks substitution or silently corrupts the bundle.
+- **Missing test coverage that would have caught this:** issues [#69](https://github.com/gofrolist/project-800ms/issues/69) (CI smoke-test asserts substitution presence, not filter behavior) and [#70](https://github.com/gofrolist/project-800ms/issues/70) (SPA filter has zero unit tests).
+- **Source PRs:** [#67](https://github.com/gofrolist/project-800ms/pull/67) introduced the per-engine TTS feature flag with the buggy sentinel; [#68](https://github.com/gofrolist/project-800ms/pull/68) replaced it with whitelist validation; [#77](https://github.com/gofrolist/project-800ms/issues/77) was the review finding that prompted this doc.
+- **Implementation files:** `apps/web/src/App.tsx` (filter logic), `apps/web/Dockerfile` (`sed` CMD), `infra/docker-compose.tls.yml` (env passthrough to the web one-shot).

--- a/services/agent/kb_retrieval.py
+++ b/services/agent/kb_retrieval.py
@@ -46,17 +46,18 @@ from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 from kb_prompts import build_grounded_messages, build_refusal_messages
 
-# Default request timeout. Issue #49: lowered from 2000 ms to 500 ms so
-# the constitution's p95 ≤ 800 ms end-to-end SLO has actual room for
-# the LLM + TTS legs after retrieval. Issue #53: the retriever's own
-# `rewriter_timeout_ms` (default 400 ms) is now SMALLER than this so
-# the retriever fails-closed to its refusal branch (writes a trace
-# row, returns 503 `rewriter_timeout`) BEFORE the agent's read budget
-# expires. If the retriever itself stalls (DB pause, container
-# restart), the agent stops waiting at 500 ms and routes to refusal —
-# losing the forensic trace row, but bounding the user-perceived
-# latency.
-_DEFAULT_TIMEOUT_MS = 500
+# Default request timeout. 2000 ms covers the local Qwen3-8B-AWQ
+# rewriter call (~600 ms TTFT + JSON gen) + hybrid SQL search +
+# serialization. External-LLM deploys (Groq llama-3.3 ~80 ms TTFT) can
+# drop it back to ~500 ms via AGENT_RETRIEVER_TIMEOUT_MS. Issue #53:
+# the retriever's own `rewriter_timeout_ms` (default 1500 ms) MUST stay
+# smaller than this so the retriever fails-closed to its refusal branch
+# (writes a trace row, returns 503 `rewriter_timeout`) BEFORE the
+# agent's read budget expires. If the retriever itself stalls (DB
+# pause, container restart), the agent stops waiting at 2000 ms and
+# routes to refusal — losing the forensic trace row but bounding the
+# user-perceived latency.
+_DEFAULT_TIMEOUT_MS = 2000
 
 
 class KBRetrievalProcessor(FrameProcessor):

--- a/services/agent/main.py
+++ b/services/agent/main.py
@@ -374,11 +374,13 @@ def main() -> None:
             # so the production deploy must wire the same secret on
             # both sides via infra/.env.
             "retriever_internal_token": os.environ.get("RETRIEVER_INTERNAL_TOKEN", ""),
-            # Issue #49: 500 ms aligns the agent budget with the
-            # constitution's 800 ms p95 SLO. Operators can override
-            # via env if a slower retriever is acceptable in their
-            # deploy.
-            "retriever_timeout_ms": int(os.environ.get("AGENT_RETRIEVER_TIMEOUT_MS", "500")),
+            # Default 2000 ms covers the local Qwen3-8B-AWQ rewriter
+            # call (~600 ms TTFT + JSON gen) + hybrid SQL search +
+            # serialization. External-LLM deploys can drop it back to
+            # ~500 ms via env. The constitutional 800 ms p95 SLO is
+            # voice-perceived (first-audio-out from end-of-speech), not
+            # the retrieve leg in isolation.
+            "retriever_timeout_ms": int(os.environ.get("AGENT_RETRIEVER_TIMEOUT_MS", "2000")),
         }
     except MissingEnvError as exc:
         logger.error(str(exc))

--- a/services/agent/pipeline.py
+++ b/services/agent/pipeline.py
@@ -135,10 +135,11 @@ class AgentConfig:
     # retriever — KBRetrievalProcessor's is_enabled gating skips the
     # call entirely when retriever_url is empty.
     retriever_internal_token: str = ""
-    # Agent-side hard timeout on the /retrieve call. Issue #49:
-    # default lowered from 2000 ms to 500 ms so the retrieval leg
-    # fits inside the constitution's 800 ms p95 end-to-end SLO.
-    retriever_timeout_ms: int = 500
+    # Agent-side hard timeout on the /retrieve call. Default 2000 ms
+    # covers the local Qwen3-8B-AWQ rewriter call (~600 ms) + hybrid
+    # SQL search + serialization. External-LLM deploys (Groq, OpenAI)
+    # can drop it back to ~500 ms because their TTFT is ~80 ms.
+    retriever_timeout_ms: int = 2000
 
     def __post_init__(self) -> None:
         if self.tts_engine not in _VALID_TTS_ENGINES:

--- a/services/agent/tests/test_main.py
+++ b/services/agent/tests/test_main.py
@@ -693,10 +693,12 @@ class TestParticipantLeftTeardown:
             # Retriever wiring (review-hardening sweep — issue #40/#47/#49).
             # Empty URL keeps KBRetrievalProcessor in pass-through mode so
             # the test pipeline doesn't try to reach a non-existent
-            # retriever during _run_pipeline assertions.
+            # retriever during _run_pipeline assertions. Value matches the
+            # post-Qwen3-swap default; the URL-empty short-circuit means
+            # the timeout is never actually exercised in this test.
             "retriever_url": "",
             "retriever_internal_token": "",
-            "retriever_timeout_ms": 500,
+            "retriever_timeout_ms": 2000,
         }
         main._active_rooms.add(room)
 

--- a/services/retriever/config.py
+++ b/services/retriever/config.py
@@ -39,13 +39,13 @@ class Settings(BaseSettings):
     rewriter_model: str = Field(min_length=1)
     # Hard timeout for the rewriter call; beyond this we fail-closed
     # (refusal). Issue #53: must be SMALLER than the agent's
-    # AGENT_RETRIEVER_TIMEOUT_MS (default 500 ms) so the retriever's
+    # AGENT_RETRIEVER_TIMEOUT_MS (default 2000 ms) so the retriever's
     # own refusal branch fires + writes its trace row before the agent
-    # gives up waiting and routes to refusal on its own. Default 400 ms
-    # leaves ~50 ms slack on top of the typical rewriter p95 against a
-    # warm Groq / vLLM endpoint, with the agent's 500 ms read budget
-    # absorbing network jitter.
-    rewriter_timeout_ms: int = Field(default=400, ge=100, le=10_000)
+    # gives up waiting and routes to refusal on its own. Default 1500 ms
+    # accommodates Qwen3-8B-AWQ TTFT (~460 ms) + JSON-mode generation;
+    # external-LLM deploys (Groq ~80 ms TTFT) can drop it back to 400 ms
+    # via env.
+    rewriter_timeout_ms: int = Field(default=1500, ge=100, le=10_000)
 
     # ── Embedder ─────────────────────────────────────────────────────────
     # "cpu" | "cuda" | "cuda:0" — passed through to sentence-transformers.


### PR DESCRIPTION
## Summary

Apply set from `/compound-engineering:ce-code-review` run `20260502-155218-b571cc30`. 10 reviewers, cross-reviewer convergence on the high-impact items, 7 fixes applied here, 9 issues filed for the deferred work.

## Changes

| File | Fix |
|---|---|
| `services/agent/main.py:381` | `AGENT_RETRIEVER_TIMEOUT_MS` Python fallback `500 → 2000` |
| `services/agent/pipeline.py:141` | `AgentConfig.retriever_timeout_ms` dataclass default `500 → 2000` |
| `services/agent/kb_retrieval.py:59` | `_DEFAULT_TIMEOUT_MS = 500 → 2000` |
| `services/agent/tests/test_main.py:699` | Fixture bumped to match new default |
| `services/retriever/config.py:48` | Pydantic `Field(default=400) → 1500` for `rewriter_timeout_ms` |
| `apps/web/src/App.tsx` | Drop `ReadonlySet<string>` widening on `VALID_ENGINE_IDS`; add `isValidEngineId` type guard; drop redundant IIFE cast; remove unreachable `VISIBLE_ENGINES.length === 0` empty-state banner |
| `apps/web/src/vite-env.d.ts` | Declare `VITE_TTS_PRELOAD_ENGINES` in `ImportMetaEnv` |

The Python timeout cluster was the highest-confidence finding (3 reviewers converged at 1.0 confidence): compose and `.env.example` were bumped to `1500/2000` ms in PR #67, but the Python in-code defaults still read `400/500` ms — every code path that hit the fallback (CI, local `uv run`, AgentConfig built without env) silently used the broken-on-Qwen3 budget that 503s every `/retrieve`.

## Deferred to follow-up issues

- #69 — Strengthen CI web smoke-test (assert filter behavior, not just sed presence)
- #70 — SPA filter unit tests (add vitest, extract IIFE)
- #71 — Dockerfile sed metacharacter validation
- #72 — vLLM chat-template bind-mount empty-dir handling
- #73 — Qwen3 chat-template upstream drift detection
- #74 — Retrieval-leg latency vs 800 ms SLO (architectural)
- #75 — Terraform cross-variable validation (xtts ↔ coqui_tos_agreed)
- #76 — Voice profile schema validation
- #77 — Document placeholder-self-collision pattern in docs/solutions/

## Test plan

- [x] `bun run build` clean
- [x] `services/agent` tests pass (28/28)
- [x] `services/retriever` rewriter tests pass (11/11)
- [x] `pre-commit run` clean on changed files
- [ ] CI green
- [ ] No regression in dev SPA — full engine catalog still rendered when `VITE_TTS_PRELOAD_ENGINES` unset